### PR TITLE
Feature/bump node vesrions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "CC0-1.0",
   "engines": {
-    "node": "14.x"
+    "node": "18.x"
   },
   "scripts": {
     "client": "cd client && npm start",

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "CC0-1.0",
   "engines": {
-    "node": "14.x"
+    "node": "18.x"
   },
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
Bump up node version to latest LTS (18) in server and orchestrating app's package.json

**Note:** Cloud Foundry needs the server app's version to be accurate, to know which version of node to install.