### PR TITLE
Feature/update monthly emissions charts

### DIFF
--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -57,14 +57,15 @@ function Chart(props: {
     ({ displacement }) => displacement.egusNeedingReplacement,
   );
 
-  const vehicleData = Object.values(totalMonthlyEmissionChanges).reduce(
+  const vehicleEmissions = Object.values(totalMonthlyEmissionChanges).reduce(
     (object, data) => {
       ['CO2', 'NOX', 'SO2', 'PM25', 'VOCs', 'NH3'].forEach((item) => {
         const pollutant = item as keyof typeof data.total;
-        const pollutantTotalData = data.total[pollutant];
+        const value = -1 * data.total[pollutant];
 
-        if (pollutantTotalData) {
-          object[pollutant].push(pollutantTotalData);
+        if (value) {
+          const result = pollutant === 'CO2' ? value / 2_000 : value;
+          object[pollutant].push(result);
         }
       });
 
@@ -89,7 +90,7 @@ function Chart(props: {
     },
     {
       name: 'Vehicles',
-      data: vehicleData.SO2,
+      data: vehicleEmissions.SO2,
       color: 'rgba(5, 141, 199, 0.5)',
       unit: 'lb',
     },
@@ -104,7 +105,7 @@ function Chart(props: {
     },
     {
       name: 'Vehicles',
-      data: vehicleData.NOX,
+      data: vehicleEmissions.NOX,
       color: 'rgba(237, 86, 27, 0.5)',
       unit: 'lb',
     },
@@ -119,7 +120,7 @@ function Chart(props: {
     },
     {
       name: 'Vehicles',
-      data: vehicleData.CO2,
+      data: vehicleEmissions.CO2,
       color: 'rgba(80, 180, 50, 0.5)',
       unit: 'tons',
     },
@@ -134,7 +135,7 @@ function Chart(props: {
     },
     {
       name: 'Vehicles',
-      data: vehicleData.PM25,
+      data: vehicleEmissions.PM25,
       color: 'rgba(102, 86, 131, 0.5)',
       unit: 'lb',
     },
@@ -149,7 +150,7 @@ function Chart(props: {
     },
     {
       name: 'Vehicles',
-      data: vehicleData.VOCs,
+      data: vehicleEmissions.VOCs,
       color: 'rgba(255, 193, 7, 0.5)',
       unit: 'lb',
     },
@@ -164,7 +165,7 @@ function Chart(props: {
     },
     {
       name: 'Vehicles',
-      data: vehicleData.NH3,
+      data: vehicleEmissions.NH3,
       color: 'rgba(0, 150, 136, 0.5)',
       unit: 'lb',
     },

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -276,6 +276,7 @@ function Chart(props: {
             return false;
           },
         },
+        stacking: 'normal',
       },
     },
     tooltip: {

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -57,6 +57,119 @@ function Chart(props: {
     ({ displacement }) => displacement.egusNeedingReplacement,
   );
 
+  const vehicleData = Object.values(totalMonthlyEmissionChanges).reduce(
+    (object, data) => {
+      ['CO2', 'NOX', 'SO2', 'PM25', 'VOCs', 'NH3'].forEach((item) => {
+        const pollutant = item as keyof typeof data.total;
+        const pollutantTotalData = data.total[pollutant];
+
+        if (pollutantTotalData) {
+          object[pollutant].push(pollutantTotalData);
+        }
+      });
+
+      return object;
+    },
+    { SO2: [], NOX: [], CO2: [], PM25: [], VOCs: [], NH3: [] } as {
+      SO2: number[];
+      NOX: number[];
+      CO2: number[];
+      PM25: number[];
+      VOCs: number[];
+      NH3: number[];
+    },
+  );
+
+  const so2Data = [
+    {
+      name: 'Power Sector',
+      data: calculateMonthlyData(powerData.so2, currentUnit),
+      color: 'rgba(5, 141, 199, 1)',
+      unit: 'lb',
+    },
+    {
+      name: 'Vehicles',
+      data: vehicleData.SO2,
+      color: 'rgba(5, 141, 199, 0.5)',
+      unit: 'lb',
+    },
+  ];
+
+  const noxData = [
+    {
+      name: 'Power Sector',
+      data: calculateMonthlyData(powerData.nox, currentUnit),
+      color: 'rgba(237, 86, 27, 1)',
+      unit: 'lb',
+    },
+    {
+      name: 'Vehicles',
+      data: vehicleData.NOX,
+      color: 'rgba(237, 86, 27, 0.5)',
+      unit: 'lb',
+    },
+  ];
+
+  const co2Data = [
+    {
+      name: 'Power Sector',
+      data: calculateMonthlyData(powerData.co2, currentUnit),
+      color: 'rgba(80, 180, 50, 1)',
+      unit: 'tons',
+    },
+    {
+      name: 'Vehicles',
+      data: vehicleData.CO2,
+      color: 'rgba(80, 180, 50, 0.5)',
+      unit: 'tons',
+    },
+  ];
+
+  const pm25Data = [
+    {
+      name: 'Power Sector',
+      data: calculateMonthlyData(powerData.pm25, currentUnit),
+      color: 'rgba(102, 86, 131, 1)',
+      unit: 'lb',
+    },
+    {
+      name: 'Vehicles',
+      data: vehicleData.PM25,
+      color: 'rgba(102, 86, 131, 0.5)',
+      unit: 'lb',
+    },
+  ];
+
+  const vocsData = [
+    {
+      name: 'Power Sector',
+      data: calculateMonthlyData(powerData.vocs, currentUnit),
+      color: 'rgba(255, 193, 7, 1)',
+      unit: 'lb',
+    },
+    {
+      name: 'Vehicles',
+      data: vehicleData.VOCs,
+      color: 'rgba(255, 193, 7, 0.5)',
+      unit: 'lb',
+    },
+  ];
+
+  const nh3Data = [
+    {
+      name: 'Power Sector',
+      data: calculateMonthlyData(powerData.nh3, currentUnit),
+      color: 'rgba(0, 150, 136, 1)',
+      unit: 'lb',
+    },
+    {
+      name: 'Vehicles',
+      data: vehicleData.NH3,
+      color: 'rgba(0, 150, 136, 0.5)',
+      unit: 'lb',
+    },
+  ];
+
   const selectedRegion = useSelectedRegion();
   const selectedStateRegions = useSelectedStateRegions();
 
@@ -187,128 +300,44 @@ function Chart(props: {
 
   const so2Config = {
     ...commonConfig,
-    title: {
-      text: formatTitle('SO<sub>2</sub>'),
-      useHTML: true,
-    },
-    yAxis: {
-      title: {
-        text: formatYAxis('lb'),
-      },
-    },
-    series: [
-      {
-        name: 'Power Sector',
-        data: calculateMonthlyData(powerData.so2, currentUnit),
-        color: 'rgba(5, 141, 199, 1)',
-        unit: 'lb',
-      },
-    ],
+    title: { text: formatTitle('SO<sub>2</sub>'), useHTML: true },
+    yAxis: { title: { text: formatYAxis('lb') } },
+    series: currentSource === 'power' ? so2Data.slice(0, 1) : so2Data,
   };
 
   const noxConfig = {
     ...commonConfig,
-    title: {
-      text: formatTitle('NO<sub>X</sub>'),
-      useHTML: true,
-    },
-    yAxis: {
-      title: {
-        text: formatYAxis('lb'),
-      },
-    },
-    series: [
-      {
-        name: 'Power Sector',
-        data: calculateMonthlyData(powerData.nox, currentUnit),
-        color: 'rgba(237, 86, 27, 1)',
-        unit: 'lb',
-      },
-    ],
+    title: { text: formatTitle('NO<sub>X</sub>'), useHTML: true },
+    yAxis: { title: { text: formatYAxis('lb') } },
+    series: currentSource === 'power' ? noxData.slice(0, 1) : noxData,
   };
 
   const co2Config = {
     ...commonConfig,
-    title: {
-      text: formatTitle('CO<sub>2</sub>'),
-      useHTML: true,
-    },
-    yAxis: {
-      title: {
-        text: formatYAxis('tons'),
-      },
-    },
-    series: [
-      {
-        name: 'Power Sector',
-        data: calculateMonthlyData(powerData.co2, currentUnit),
-        color: 'rgba(80, 180, 50, 1)',
-        unit: 'tons',
-      },
-    ],
+    title: { text: formatTitle('CO<sub>2</sub>'), useHTML: true },
+    yAxis: { title: { text: formatYAxis('tons') } },
+    series: currentSource === 'power' ? co2Data.slice(0, 1) : co2Data,
   };
 
   const pm25Config = {
     ...commonConfig,
-    title: {
-      text: formatTitle('PM<sub>2.5</sub>'),
-      useHTML: true,
-    },
-    yAxis: {
-      title: {
-        text: formatYAxis('lb'),
-      },
-    },
-    series: [
-      {
-        name: 'Power Sector',
-        data: calculateMonthlyData(powerData.pm25, currentUnit),
-        color: 'rgba(102, 86, 131, 1)',
-        unit: 'lb',
-      },
-    ],
+    title: { text: formatTitle('PM<sub>2.5</sub>'), useHTML: true },
+    yAxis: { title: { text: formatYAxis('lb') } },
+    series: currentSource === 'power' ? pm25Data.slice(0, 1) : pm25Data,
   };
 
   const vocsConfig = {
     ...commonConfig,
-    title: {
-      text: formatTitle('VOC'),
-      useHTML: true,
-    },
-    yAxis: {
-      title: {
-        text: formatYAxis('lb'),
-      },
-    },
-    series: [
-      {
-        name: 'Power Sector',
-        data: calculateMonthlyData(powerData.vocs, currentUnit),
-        color: 'rgba(255, 193, 7, 1)',
-        unit: 'lb',
-      },
-    ],
+    title: { text: formatTitle('VOC'), useHTML: true },
+    yAxis: { title: { text: formatYAxis('lb') } },
+    series: currentSource === 'power' ? vocsData.slice(0, 1) : vocsData,
   };
 
   const nh3Config = {
     ...commonConfig,
-    title: {
-      text: formatTitle('NH<sub>3</sub>'),
-      useHTML: true,
-    },
-    yAxis: {
-      title: {
-        text: formatYAxis('lb'),
-      },
-    },
-    series: [
-      {
-        name: 'Power Sector',
-        data: calculateMonthlyData(powerData.nh3, currentUnit),
-        color: 'rgba(0, 150, 136, 1)',
-        unit: 'lb',
-      },
-    ],
+    title: { text: formatTitle('NH<sub>3</sub>'), useHTML: true },
+    yAxis: { title: { text: formatYAxis('lb') } },
+    series: currentSource === 'power' ? nh3Data.slice(0, 1) : nh3Data,
   };
 
   // prettier-ignore

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -16,7 +16,7 @@ import {
   setMonthlyEmissionsCountyName,
   setMonthlyEmissionsPollutant,
   setMonthlyEmissionsSource,
-  seMonthlyEmissionsUnit,
+  setMonthlyEmissionsUnit,
 } from 'app/redux/reducers/monthlyEmissions';
 import { useSelectedRegion, useSelectedStateRegions } from 'app/hooks';
 import type { Pollutant, RegionId, StateId } from 'app/config';
@@ -906,7 +906,7 @@ export function MonthlyEmissionsCharts() {
                       value="emissions"
                       checked={currentUnit === 'emissions'}
                       onChange={(_ev) => {
-                        dispatch(seMonthlyEmissionsUnit('emissions'));
+                        dispatch(setMonthlyEmissionsUnit('emissions'));
                       }}
                       data-avert-unit-toggle="emissions"
                     />
@@ -931,7 +931,8 @@ export function MonthlyEmissionsCharts() {
                       value="percentages"
                       checked={currentUnit === 'percentages'}
                       onChange={(_ev) => {
-                        dispatch(seMonthlyEmissionsUnit('percentages'));
+                        dispatch(setMonthlyEmissionsUnit('percentages'));
+                        dispatch(setMonthlyEmissionsSource('power'));
                       }}
                       data-avert-unit-toggle="percentages"
                     />

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -873,6 +873,7 @@ export function MonthlyEmissionsCharts() {
                       }
                       onChange={(_ev) => {
                         dispatch(setMonthlyEmissionsSource('power-vehicles'));
+                        dispatch(setMonthlyEmissionsUnit('emissions'));
                       }}
                       data-avert-source-toggle="power-vehicles"
                     />

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -27,11 +27,14 @@ require('highcharts/modules/accessibility')(Highcharts);
 
 function Chart(props: {
   pollutant: Pollutant;
-  data: { [key in Pollutant]: MonthlyDisplacement };
+  powerData: { [key in Pollutant]: MonthlyDisplacement };
 }) {
-  const { pollutant, data } = props;
+  const { pollutant, powerData } = props;
 
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
+  const totalMonthlyEmissionChanges = useTypedSelector(
+    ({ transportation }) => transportation.totalMonthlyEmissionChanges,
+  );
   const currentAggregation = useTypedSelector(
     ({ monthlyEmissions }) => monthlyEmissions.aggregation,
   );
@@ -43,6 +46,9 @@ function Chart(props: {
   );
   const currentCountyName = useTypedSelector(
     ({ monthlyEmissions }) => monthlyEmissions.countyName,
+  );
+  const currentSource = useTypedSelector(
+    ({ monthlyEmissions }) => monthlyEmissions.source,
   );
   const currentUnit = useTypedSelector(
     ({ monthlyEmissions }) => monthlyEmissions.unit,
@@ -131,7 +137,7 @@ function Chart(props: {
   const commonConfig: Highcharts.Options = {
     chart: {
       type: 'column',
-      height: 240,
+      height: 300,
       style: {
         fontFamily: '"Open Sans", sans-serif',
       },
@@ -146,11 +152,16 @@ function Chart(props: {
       contextButtonTitle: 'Export options',
     },
     legend: {
-      enabled: false,
+      enabled: true,
     },
     plotOptions: {
       series: {
         animation: false,
+        events: {
+          legendItemClick: function () {
+            return false;
+          },
+        },
       },
     },
     tooltip: {
@@ -187,9 +198,9 @@ function Chart(props: {
     },
     series: [
       {
-        name: 'SO₂',
-        data: calculateMonthlyData(data.so2, currentUnit),
-        color: '#058dc7',
+        name: 'Power Sector',
+        data: calculateMonthlyData(powerData.so2, currentUnit),
+        color: 'rgba(5, 141, 199, 1)',
         unit: 'lb',
       },
     ],
@@ -208,9 +219,9 @@ function Chart(props: {
     },
     series: [
       {
-        name: 'NOₓ',
-        data: calculateMonthlyData(data.nox, currentUnit),
-        color: '#ed561b',
+        name: 'Power Sector',
+        data: calculateMonthlyData(powerData.nox, currentUnit),
+        color: 'rgba(237, 86, 27, 1)',
         unit: 'lb',
       },
     ],
@@ -229,9 +240,9 @@ function Chart(props: {
     },
     series: [
       {
-        name: 'CO₂',
-        data: calculateMonthlyData(data.co2, currentUnit),
-        color: '#50b432',
+        name: 'Power Sector',
+        data: calculateMonthlyData(powerData.co2, currentUnit),
+        color: 'rgba(80, 180, 50, 1)',
         unit: 'tons',
       },
     ],
@@ -250,9 +261,9 @@ function Chart(props: {
     },
     series: [
       {
-        name: 'PM₂₅',
-        data: calculateMonthlyData(data.pm25, currentUnit),
-        color: '#665683',
+        name: 'Power Sector',
+        data: calculateMonthlyData(powerData.pm25, currentUnit),
+        color: 'rgba(102, 86, 131, 1)',
         unit: 'lb',
       },
     ],
@@ -271,9 +282,9 @@ function Chart(props: {
     },
     series: [
       {
-        name: 'VOC',
-        data: calculateMonthlyData(data.vocs, currentUnit),
-        color: '#ffc107',
+        name: 'Power Sector',
+        data: calculateMonthlyData(powerData.vocs, currentUnit),
+        color: 'rgba(255, 193, 7, 1)',
         unit: 'lb',
       },
     ],
@@ -292,9 +303,9 @@ function Chart(props: {
     },
     series: [
       {
-        name: 'NH₃',
-        data: calculateMonthlyData(data.nh3, currentUnit),
-        color: '#009688',
+        name: 'Power Sector',
+        data: calculateMonthlyData(powerData.nh3, currentUnit),
+        color: 'rgba(0, 150, 136, 1)',
         unit: 'lb',
       },
     ],
@@ -415,7 +426,7 @@ export function MonthlyEmissionsCharts() {
     month12: { original: 0, postEere: 0 },
   };
 
-  const data: { [key in Pollutant]: MonthlyDisplacement } = {
+  const powerData: { [key in Pollutant]: MonthlyDisplacement } = {
     so2: { ...initialMonthlyData },
     nox: { ...initialMonthlyData },
     co2: { ...initialMonthlyData },
@@ -438,21 +449,21 @@ export function MonthlyEmissionsCharts() {
 
     if (currentAggregation === 'region') {
       const displacement = monthlyEmissionChanges.regions[pollutant][regionId];
-      data[pollutant] = displacement || initialMonthlyData;
+      powerData[pollutant] = displacement || initialMonthlyData;
     }
 
     if (currentAggregation === 'state') {
       const displacement = monthlyEmissionChanges.states[pollutant][stateId];
-      data[pollutant] = displacement || initialMonthlyData;
+      powerData[pollutant] = displacement || initialMonthlyData;
     }
 
     if (currentAggregation === 'county') {
       const displacement = monthlyEmissionChanges.counties[pollutant][stateId]?.[currentCountyName]; // prettier-ignore
-      data[pollutant] = displacement || initialMonthlyData;
+      powerData[pollutant] = displacement || initialMonthlyData;
     }
   }
 
-  // console.log(data); // NOTE: for debugging purposes
+  // console.log(powerData); // NOTE: for debugging purposes
 
   return (
     <>
@@ -945,7 +956,11 @@ export function MonthlyEmissionsCharts() {
 
                   return (
                     <div key={pollutant} className={className}>
-                      <Chart key={key} pollutant={pollutant} data={data} />
+                      <Chart
+                        key={key}
+                        pollutant={pollutant}
+                        powerData={powerData}
+                      />
                     </div>
                   );
                 })

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -412,18 +412,18 @@ export function MonthlyEmissionsCharts() {
 
   // set monthlyData for each pollutant, based on selected aggregation
   const initialMonthlyData = {
-    month1: { original: 0, postEere: 0 },
-    month2: { original: 0, postEere: 0 },
-    month3: { original: 0, postEere: 0 },
-    month4: { original: 0, postEere: 0 },
-    month5: { original: 0, postEere: 0 },
-    month6: { original: 0, postEere: 0 },
-    month7: { original: 0, postEere: 0 },
-    month8: { original: 0, postEere: 0 },
-    month9: { original: 0, postEere: 0 },
-    month10: { original: 0, postEere: 0 },
-    month11: { original: 0, postEere: 0 },
-    month12: { original: 0, postEere: 0 },
+    1: { original: 0, postEere: 0 },
+    2: { original: 0, postEere: 0 },
+    3: { original: 0, postEere: 0 },
+    4: { original: 0, postEere: 0 },
+    5: { original: 0, postEere: 0 },
+    6: { original: 0, postEere: 0 },
+    7: { original: 0, postEere: 0 },
+    8: { original: 0, postEere: 0 },
+    9: { original: 0, postEere: 0 },
+    10: { original: 0, postEere: 0 },
+    11: { original: 0, postEere: 0 },
+    12: { original: 0, postEere: 0 },
   };
 
   const powerData: { [key in Pollutant]: MonthlyDisplacement } = {

--- a/client/src/app/components/TransportationSectorEmissionsTable.tsx
+++ b/client/src/app/components/TransportationSectorEmissionsTable.tsx
@@ -7,10 +7,10 @@ function formatNumber(number: number) {
 }
 
 export function TransportationSectorEmissionsTable() {
+  const status = useTypedSelector(({ displacement }) => displacement.status);
   const totalYearlyVehicleEmissionsChanges = useTypedSelector(
     ({ transportation }) => transportation.totalYearlyEmissionChanges,
   );
-
   const annualStateEmissionChanges = useTypedSelector(
     ({ displacement }) => displacement.annualStateEmissionChanges,
   );
@@ -50,6 +50,8 @@ export function TransportationSectorEmissionsTable() {
   const totalYearlyNetPM25 = totalYearlyVehiclePM25 + totalYearlyPowerPM25;
   const totalYearlyNetVOCs = totalYearlyVehicleVOCs + totalYearlyPowerVOCs;
   const totalYearlyNetNH3 = totalYearlyVehicleNH3 + totalYearlyPowerNH3;
+
+  if (status !== 'complete') return null;
 
   return (
     <>

--- a/client/src/app/redux/reducers/displacement.ts
+++ b/client/src/app/redux/reducers/displacement.ts
@@ -25,22 +25,8 @@ type ReplacementEGUsByPollutant = {
   [key in ReplacementPollutantName]: (EGUData & { regionId: RegionId })[];
 };
 
-type MonthKey =
-  | 'month1'
-  | 'month2'
-  | 'month3'
-  | 'month4'
-  | 'month5'
-  | 'month6'
-  | 'month7'
-  | 'month8'
-  | 'month9'
-  | 'month10'
-  | 'month11'
-  | 'month12';
-
 export type MonthlyDisplacement = {
-  [month in MonthKey]: {
+  [month: number]: {
     original: number;
     postEere: number;
   };
@@ -507,8 +493,9 @@ function fetchDisplacementData(
 
                 // total each month's state emissions change for the given state
                 let stateEmissionsChange = 0;
-                for (const month in stateData) {
-                  const { original, postEere } = stateData[month as MonthKey];
+                for (const stateDataKey in stateData) {
+                  const month = Number(stateDataKey);
+                  const { original, postEere } = stateData[month];
                   stateEmissionsChange += postEere - original;
                 }
 
@@ -618,8 +605,9 @@ export function calculateMonthlyData(data: MonthlyDisplacement, unit: Unit) {
   const monthlyEmissionsChanges: number[] = [];
   const monthlyPercentageChanges: number[] = [];
 
-  for (const month in data) {
-    const { original, postEere } = data[month as MonthKey];
+  for (const dataKey in data) {
+    const month = Number(dataKey);
+    const { original, postEere } = data[month];
     const emissionsChange = postEere - original;
     const percentChange = (emissionsChange / original) * 100 || 0;
     monthlyEmissionsChanges.push(emissionsChange);
@@ -768,23 +756,19 @@ function setAnnualRegionalDisplacements(
       // each region's regional generation and nox data from the months of May
       // through September
       if (item === 'ozoneGeneration' || item === 'ozoneNox') {
-        const ozoneMonths = ['month5', 'month6', 'month7', 'month8', 'month9'];
+        const ozoneMonths = [5, 6, 7, 8, 9];
 
         if (item === 'ozoneGeneration') {
           ozoneMonths.forEach((month) => {
-            const m = month as MonthKey;
-            data.ozoneGeneration.original +=
-              displacement.generation.regionalData[m].original;
-            data.ozoneGeneration.postEere +=
-              displacement.generation.regionalData[m].postEere;
+            data.ozoneGeneration.original += displacement.generation.regionalData[month].original; // prettier-ignore
+            data.ozoneGeneration.postEere += displacement.generation.regionalData[month].postEere; // prettier-ignore
           });
         }
 
         if (item === 'ozoneNox') {
           ozoneMonths.forEach((month) => {
-            const m = month as MonthKey;
-            data.ozoneNox.original += displacement.nox.regionalData[m].original;
-            data.ozoneNox.postEere += displacement.nox.regionalData[m].postEere;
+            data.ozoneNox.original += displacement.nox.regionalData[month].original; // prettier-ignore
+            data.ozoneNox.postEere += displacement.nox.regionalData[month].postEere; // prettier-ignore
           });
         }
       }
@@ -874,98 +858,98 @@ function setMonthlyEmissionChanges(
   const regionsDisplacements: RegionsDisplacementsByPollutant = {
     so2: {
       ['ALL' as RegionId]: {
-        month1: { original: 0, postEere: 0 },
-        month2: { original: 0, postEere: 0 },
-        month3: { original: 0, postEere: 0 },
-        month4: { original: 0, postEere: 0 },
-        month5: { original: 0, postEere: 0 },
-        month6: { original: 0, postEere: 0 },
-        month7: { original: 0, postEere: 0 },
-        month8: { original: 0, postEere: 0 },
-        month9: { original: 0, postEere: 0 },
-        month10: { original: 0, postEere: 0 },
-        month11: { original: 0, postEere: 0 },
-        month12: { original: 0, postEere: 0 },
+        1: { original: 0, postEere: 0 },
+        2: { original: 0, postEere: 0 },
+        3: { original: 0, postEere: 0 },
+        4: { original: 0, postEere: 0 },
+        5: { original: 0, postEere: 0 },
+        6: { original: 0, postEere: 0 },
+        7: { original: 0, postEere: 0 },
+        8: { original: 0, postEere: 0 },
+        9: { original: 0, postEere: 0 },
+        10: { original: 0, postEere: 0 },
+        11: { original: 0, postEere: 0 },
+        12: { original: 0, postEere: 0 },
       },
     },
     nox: {
       ['ALL' as RegionId]: {
-        month1: { original: 0, postEere: 0 },
-        month2: { original: 0, postEere: 0 },
-        month3: { original: 0, postEere: 0 },
-        month4: { original: 0, postEere: 0 },
-        month5: { original: 0, postEere: 0 },
-        month6: { original: 0, postEere: 0 },
-        month7: { original: 0, postEere: 0 },
-        month8: { original: 0, postEere: 0 },
-        month9: { original: 0, postEere: 0 },
-        month10: { original: 0, postEere: 0 },
-        month11: { original: 0, postEere: 0 },
-        month12: { original: 0, postEere: 0 },
+        1: { original: 0, postEere: 0 },
+        2: { original: 0, postEere: 0 },
+        3: { original: 0, postEere: 0 },
+        4: { original: 0, postEere: 0 },
+        5: { original: 0, postEere: 0 },
+        6: { original: 0, postEere: 0 },
+        7: { original: 0, postEere: 0 },
+        8: { original: 0, postEere: 0 },
+        9: { original: 0, postEere: 0 },
+        10: { original: 0, postEere: 0 },
+        11: { original: 0, postEere: 0 },
+        12: { original: 0, postEere: 0 },
       },
     },
     co2: {
       ['ALL' as RegionId]: {
-        month1: { original: 0, postEere: 0 },
-        month2: { original: 0, postEere: 0 },
-        month3: { original: 0, postEere: 0 },
-        month4: { original: 0, postEere: 0 },
-        month5: { original: 0, postEere: 0 },
-        month6: { original: 0, postEere: 0 },
-        month7: { original: 0, postEere: 0 },
-        month8: { original: 0, postEere: 0 },
-        month9: { original: 0, postEere: 0 },
-        month10: { original: 0, postEere: 0 },
-        month11: { original: 0, postEere: 0 },
-        month12: { original: 0, postEere: 0 },
+        1: { original: 0, postEere: 0 },
+        2: { original: 0, postEere: 0 },
+        3: { original: 0, postEere: 0 },
+        4: { original: 0, postEere: 0 },
+        5: { original: 0, postEere: 0 },
+        6: { original: 0, postEere: 0 },
+        7: { original: 0, postEere: 0 },
+        8: { original: 0, postEere: 0 },
+        9: { original: 0, postEere: 0 },
+        10: { original: 0, postEere: 0 },
+        11: { original: 0, postEere: 0 },
+        12: { original: 0, postEere: 0 },
       },
     },
     pm25: {
       ['ALL' as RegionId]: {
-        month1: { original: 0, postEere: 0 },
-        month2: { original: 0, postEere: 0 },
-        month3: { original: 0, postEere: 0 },
-        month4: { original: 0, postEere: 0 },
-        month5: { original: 0, postEere: 0 },
-        month6: { original: 0, postEere: 0 },
-        month7: { original: 0, postEere: 0 },
-        month8: { original: 0, postEere: 0 },
-        month9: { original: 0, postEere: 0 },
-        month10: { original: 0, postEere: 0 },
-        month11: { original: 0, postEere: 0 },
-        month12: { original: 0, postEere: 0 },
+        1: { original: 0, postEere: 0 },
+        2: { original: 0, postEere: 0 },
+        3: { original: 0, postEere: 0 },
+        4: { original: 0, postEere: 0 },
+        5: { original: 0, postEere: 0 },
+        6: { original: 0, postEere: 0 },
+        7: { original: 0, postEere: 0 },
+        8: { original: 0, postEere: 0 },
+        9: { original: 0, postEere: 0 },
+        10: { original: 0, postEere: 0 },
+        11: { original: 0, postEere: 0 },
+        12: { original: 0, postEere: 0 },
       },
     },
     vocs: {
       ['ALL' as RegionId]: {
-        month1: { original: 0, postEere: 0 },
-        month2: { original: 0, postEere: 0 },
-        month3: { original: 0, postEere: 0 },
-        month4: { original: 0, postEere: 0 },
-        month5: { original: 0, postEere: 0 },
-        month6: { original: 0, postEere: 0 },
-        month7: { original: 0, postEere: 0 },
-        month8: { original: 0, postEere: 0 },
-        month9: { original: 0, postEere: 0 },
-        month10: { original: 0, postEere: 0 },
-        month11: { original: 0, postEere: 0 },
-        month12: { original: 0, postEere: 0 },
+        1: { original: 0, postEere: 0 },
+        2: { original: 0, postEere: 0 },
+        3: { original: 0, postEere: 0 },
+        4: { original: 0, postEere: 0 },
+        5: { original: 0, postEere: 0 },
+        6: { original: 0, postEere: 0 },
+        7: { original: 0, postEere: 0 },
+        8: { original: 0, postEere: 0 },
+        9: { original: 0, postEere: 0 },
+        10: { original: 0, postEere: 0 },
+        11: { original: 0, postEere: 0 },
+        12: { original: 0, postEere: 0 },
       },
     },
     nh3: {
       ['ALL' as RegionId]: {
-        month1: { original: 0, postEere: 0 },
-        month2: { original: 0, postEere: 0 },
-        month3: { original: 0, postEere: 0 },
-        month4: { original: 0, postEere: 0 },
-        month5: { original: 0, postEere: 0 },
-        month6: { original: 0, postEere: 0 },
-        month7: { original: 0, postEere: 0 },
-        month8: { original: 0, postEere: 0 },
-        month9: { original: 0, postEere: 0 },
-        month10: { original: 0, postEere: 0 },
-        month11: { original: 0, postEere: 0 },
-        month12: { original: 0, postEere: 0 },
+        1: { original: 0, postEere: 0 },
+        2: { original: 0, postEere: 0 },
+        3: { original: 0, postEere: 0 },
+        4: { original: 0, postEere: 0 },
+        5: { original: 0, postEere: 0 },
+        6: { original: 0, postEere: 0 },
+        7: { original: 0, postEere: 0 },
+        8: { original: 0, postEere: 0 },
+        9: { original: 0, postEere: 0 },
+        10: { original: 0, postEere: 0 },
+        11: { original: 0, postEere: 0 },
+        12: { original: 0, postEere: 0 },
       },
     },
   };
@@ -1007,22 +991,22 @@ function setMonthlyEmissionChanges(
         // add up total displacements for the pollutant for all regions
         const allRegions = regionsDisplacements[pollutant]['ALL' as RegionId];
 
-        for (const key in allRegions) {
-          const month = key as MonthKey;
+        for (const allRegionsKey in allRegions) {
+          const month = Number(allRegionsKey);
           allRegions[month].original += regionalData[month].original;
           allRegions[month].postEere += regionalData[month].postEere;
         }
 
         // add (and potentially combine) state data for the pollutant
-        for (const key in stateData) {
-          const stateId = key as StateId;
+        for (const stateDataKey in stateData) {
+          const stateId = stateDataKey as StateId;
           // if a state's pollutant data already exists for the pollutant,
           // it was already added from another region, so add this regions's
           // monthly displacement data for the pollutant for the state
           if (statesDisplacements[pollutant][stateId]) {
             const dataset = statesDisplacements[pollutant][stateId];
-            for (const key in dataset) {
-              const month = key as MonthKey;
+            for (const datasetKey in dataset) {
+              const month = Number(datasetKey);
               dataset[month].original += stateData[stateId][month].original;
               dataset[month].postEere += stateData[stateId][month].postEere;
             }

--- a/client/src/app/redux/reducers/monthlyEmissions.ts
+++ b/client/src/app/redux/reducers/monthlyEmissions.ts
@@ -195,7 +195,7 @@ export function setMonthlyEmissionsSource(source: Source) {
   };
 }
 
-export function seMonthlyEmissionsUnit(unit: Unit) {
+export function setMonthlyEmissionsUnit(unit: Unit) {
   return {
     type: 'monthlyEmissions/SET_MONTHLY_EMISSIONS_UNIT',
     payload: { unit },

--- a/server/app/calculations.js
+++ b/server/app/calculations.js
@@ -107,19 +107,20 @@
  */
 
 /**
- * @typedef {Object} MonthlyDisplacement
- * @property {Displacement} month1
- * @property {Displacement} month2
- * @property {Displacement} month3
- * @property {Displacement} month4
- * @property {Displacement} month5
- * @property {Displacement} month6
- * @property {Displacement} month7
- * @property {Displacement} month8
- * @property {Displacement} month9
- * @property {Displacement} month10
- * @property {Displacement} month11
- * @property {Displacement} month12
+ * @typedef {{
+ *  1: Displacement,
+ *  2: Displacement,
+ *  3: Displacement,
+ *  4: Displacement,
+ *  5: Displacement,
+ *  6: Displacement,
+ *  7: Displacement,
+ *  8: Displacement,
+ *  9: Displacement,
+ *  10: Displacement,
+ *  11: Displacement,
+ *  12: Displacement,
+ * }} MonthlyDisplacement
  */
 
 /**
@@ -382,20 +383,20 @@ function getDisplacement({ year, metric, rdfJson, neiJson, eereLoad, debug }) {
         // individually here is computationally smarter as it means we don't need
         // to re-iterate over data structures later to sum those totals
 
-        regionalData[pollutant][`month${month}`] ??= { original: 0, postEere: 0 }; // prettier-ignore
-        regionalData[pollutant][`month${month}`].original += original[pollutant]; // prettier-ignore
-        regionalData[pollutant][`month${month}`].postEere += postEere[pollutant]; // prettier-ignore
+        regionalData[pollutant][month] ??= { original: 0, postEere: 0 };
+        regionalData[pollutant][month].original += original[pollutant];
+        regionalData[pollutant][month].postEere += postEere[pollutant];
 
         stateData[pollutant][stateId] ??= {};
-        stateData[pollutant][stateId][`month${month}`] ??= { original: 0, postEere: 0 }; // prettier-ignore
-        stateData[pollutant][stateId][`month${month}`].original += original[pollutant]; // prettier-ignore
-        stateData[pollutant][stateId][`month${month}`].postEere += postEere[pollutant]; // prettier-ignore
+        stateData[pollutant][stateId][month] ??= { original: 0, postEere: 0 };
+        stateData[pollutant][stateId][month].original += original[pollutant];
+        stateData[pollutant][stateId][month].postEere += postEere[pollutant];
 
         countyData[pollutant][stateId] ??= {};
         countyData[pollutant][stateId][county] ??= {};
-        countyData[pollutant][stateId][county][`month${month}`] ??= { original: 0, postEere: 0 }; // prettier-ignore
-        countyData[pollutant][stateId][county][`month${month}`].original += original[pollutant]; // prettier-ignore
-        countyData[pollutant][stateId][county][`month${month}`].postEere += postEere[pollutant]; // prettier-ignore
+        countyData[pollutant][stateId][county][month] ??= { original: 0, postEere: 0 }; // prettier-ignore
+        countyData[pollutant][stateId][county][month].original += original[pollutant]; // prettier-ignore
+        countyData[pollutant][stateId][county][month].postEere += postEere[pollutant]; // prettier-ignore
 
         // NOTE: hourlyData isn't returned normally as the resulting object is
         // huge (several hundred MB). this is just added as a means to verify


### PR DESCRIPTION
Update monthly emissions charts to show vehicle data as well as power sector data, and update storing of monthly data in displacements calculations to use month numbers as keys (e.g. 1, 2, 3) instead of 'month' prefixed strings (e.g. 'month1', 'month2', 'month3') to match format of calculated monthly transportation data in the client app (for easier/more consistent use in functions that use both sets of calculated data).