### PR TITLE
Feature/add eere ev message

### DIFF
--- a/client/src/app/components/EEREChart.tsx
+++ b/client/src/app/components/EEREChart.tsx
@@ -4,10 +4,99 @@ import HighchartsReact from 'highcharts-react-official';
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { Tooltip } from 'app/components/Tooltip';
 import { useTypedSelector } from 'app/redux/index';
+import type { RegionalLoadData } from 'app/redux/reducers/geography';
 import { useSelectedRegion, useSelectedStateRegions } from 'app/hooks';
 
 require('highcharts/modules/exporting')(Highcharts);
 require('highcharts/modules/accessibility')(Highcharts);
+
+function EquivalentHomesText(props: { hourlyEere: number[] }) {
+  const { hourlyEere } = props;
+
+  const totalLoadMwh = hourlyEere.reduce((a, b) => a + b, 0);
+  const totalLoadGwh = Math.round(totalLoadMwh / -1_000);
+
+  /**
+   * the annual kwh of electricity used by the average american home is 12,146
+   */
+  const equivalentHomes = Math.round((totalLoadMwh / 12_146) * -1_000);
+
+  return (
+    <p className="margin-top-2 text-base-dark">
+      This EE/RE profile will displace{' '}
+      <strong>{totalLoadGwh.toLocaleString()} GWh</strong> of regional fossil
+      fuel generation over the course of a year. For reference, this equals the
+      annual electricity consumed by{' '}
+      <strong>{equivalentHomes.toLocaleString()}</strong> average homes in the
+      United States.
+    </p>
+  );
+}
+
+function ValidationMessage(props: {
+  type: 'error' | 'warning';
+  value: number;
+  timestamp: RegionalLoadData;
+}) {
+  const { type, value, timestamp } = props;
+
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  const month = months[timestamp.month - 1];
+  const day = timestamp.day;
+  const hour =
+    timestamp.hour === 0
+      ? 12
+      : timestamp.hour > 12
+      ? timestamp.hour - 12
+      : timestamp.hour;
+  const ampm = timestamp.hour > 12 ? 'PM' : 'AM';
+  const percentage = value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+
+  return (
+    <div className={`usa-alert usa-alert--${type} margin-bottom-0`}>
+      <div className="usa-alert__body">
+        <h4 className="usa-alert__heading">
+          {type === 'error' ? 'ERROR' : 'WARNING'}
+        </h4>
+        <p>
+          The combined impact of your proposed programs would displace more than{' '}
+          <strong>{type === 'error' ? '30' : '15'}%</strong> of regional fossil
+          generation in at least one hour of the year.&nbsp;&nbsp;
+          <em>
+            (Maximum value: <strong>{percentage}</strong>% on{' '}
+            <strong>
+              {month} {day} at {hour}:00 {ampm}
+            </strong>
+            ).
+          </em>
+        </p>
+
+        <p className="margin-0">
+          The recommended limit for AVERT is 15%, as AVERT is designed to
+          simulate marginal operational changes in load, rather than large-scale
+          changes that may change fundamental dynamics. Please reduce one or
+          more of your inputs to ensure more reliable results.
+        </p>
+      </div>
+    </div>
+  );
+}
 
 function EEREChartContent() {
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
@@ -110,158 +199,60 @@ function EEREChartContent() {
     ],
   };
 
-  // boolean flag to render chart and error/warning when hourlyEere exits
-  let readyToRender = hourlyEere?.length > 0;
-
-  let chart = null;
-  // conditionally re-define chart when readyToRender (hourlyEere exists)
-
-  if (readyToRender) {
-    const totalLoadMwh = hourlyEere.reduce((a, b) => a + b, 0);
-    const totalLoadGwh = Math.round(totalLoadMwh / -1_000);
-
-    // calculate the total equivalent number of american homes
-    // (annual kwh of electricity used by the average american home is 12,146)
-    const equivalentHomes = Math.round((totalLoadMwh / 12_146) * -1_000);
-
-    chart = (
-      <>
-        <h3 className="margin-0 font-sans-md line-height-sans-2 text-base-darker text-center">
-          EE/RE profile based on values entered:&nbsp;
-          <Tooltip id="eere-profile">
-            <p className="margin-0 font-sans-sm text-base-darkest text-normal text-left">
-              This graph shows the hourly changes in load that will result from
-              the inputs entered above. It reflects a combination of all inputs,
-              typical capacity factors for wind and solar, and adjustments for
-              avoided transmission and distribution line loss, where applicable.
-              This hourly EE/RE profile will be used to calculate the avoided
-              emissions for this AVERT region.
-            </p>
-          </Tooltip>
-        </h3>
-
-        <h4 className="margin-top-1 font-sans-2xs text-base-darker text-normal text-center">
-          Adjusted for transmission and distribution line loss and wind and
-          solar capacity factors, where applicable.
-        </h4>
-
-        <HighchartsReact
-          highcharts={Highcharts}
-          options={chartConfig}
-          callback={(_chart: Highcharts.Chart) => {
-            // callback for after highcharts chart renders
-            // as this entire react app is ultimately served in an iframe on another page,
-            // this document has a click handler that sends document's height to other window,
-            // which can then set the embedded iframe's height (see public/post-message.js)
-            document.querySelector('html')?.click();
-          }}
-        />
-
-        <p className="margin-top-2 text-base-dark">
-          This EE/RE profile will displace{' '}
-          <strong>{totalLoadGwh.toLocaleString()} GWh</strong> of regional
-          fossil fuel generation over the course of a year. For reference, this
-          equals the annual electricity consumed by{' '}
-          <strong>{equivalentHomes.toLocaleString()}</strong> average homes in
-          the United States.
-        </p>
-      </>
-    );
-  }
-
-  function validationMessage(type: 'error' | 'warning') {
-    const x = {
-      heading: '',
-      threshold: '',
-      value: 0,
-      timestamp: { month: 0, day: 0, hour: 0 },
-    };
-
-    if (type === 'error') {
-      x.heading = 'ERROR';
-      x.threshold = '30';
-      x.value = hardTopExceedanceValue;
-      x.timestamp = hardTopExceedanceTimestamp;
-    }
-
-    if (type === 'warning') {
-      x.heading = 'WARNING';
-      x.threshold = '15';
-      x.value = softTopExceedanceValue;
-      x.timestamp = softTopExceedanceTimestamp;
-    }
-
-    const months = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ];
-    const month = months[x.timestamp.month - 1];
-    const day = x.timestamp.day;
-    const hour =
-      x.timestamp.hour === 0
-        ? 12
-        : x.timestamp.hour > 12
-        ? x.timestamp.hour - 12
-        : x.timestamp.hour;
-    const ampm = x.timestamp.hour > 12 ? 'PM' : 'AM';
-    const percentage = x.value.toLocaleString(undefined, {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 2,
-    });
-
-    return (
-      <div className={`usa-alert usa-alert--${type} margin-bottom-0`}>
-        <div className="usa-alert__body">
-          <h4 className="usa-alert__heading">{x.heading}</h4>
-          <p>
-            The combined impact of your proposed programs would displace more
-            than <strong>{x.threshold}%</strong> of regional fossil generation
-            in at least one hour of the year.&nbsp;&nbsp;
-            <em>
-              (Maximum value: <strong>{percentage}</strong>% on{' '}
-              <strong>
-                {month} {day} at {hour}:00 {ampm}
-              </strong>
-              ).
-            </em>
-          </p>
-
-          <p className="margin-0">
-            The recommended limit for AVERT is 15%, as AVERT is designed to
-            simulate marginal operational changes in load, rather than
-            large-scale changes that may change fundamental dynamics. Please
-            reduce one or more of your inputs to ensure more reliable results.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  // set validationError when readyToRender and hardValid is false
-  const validationError =
-    readyToRender && !hardValid ? validationMessage('error') : null;
-
-  // set validationWarning when readyToRender, softValid is false, and hardValid is true
-  const validationWarning =
-    readyToRender && !softValid && hardValid
-      ? validationMessage('warning')
-      : null;
-
   return (
     <div data-avert-chart>
-      {chart}
-      {validationError}
-      {validationWarning}
+      {hourlyEere?.length > 0 && (
+        <>
+          <h3 className="margin-0 font-sans-md line-height-sans-2 text-base-darker text-center">
+            EE/RE profile based on values entered:&nbsp;
+            <Tooltip id="eere-profile">
+              <p className="margin-0 font-sans-sm text-base-darkest text-normal text-left">
+                This graph shows the hourly changes in load that will result
+                from the inputs entered above. It reflects a combination of all
+                inputs, typical capacity factors for wind and solar, and
+                adjustments for avoided transmission and distribution line loss,
+                where applicable. This hourly EE/RE profile will be used to
+                calculate the avoided emissions for this AVERT region.
+              </p>
+            </Tooltip>
+          </h3>
+
+          <h4 className="margin-top-1 font-sans-2xs text-base-darker text-normal text-center">
+            Adjusted for transmission and distribution line loss and wind and
+            solar capacity factors, where applicable.
+          </h4>
+
+          <HighchartsReact
+            highcharts={Highcharts}
+            options={chartConfig}
+            callback={(_chart: Highcharts.Chart) => {
+              // callback for after highcharts chart renders
+              // as this entire react app is ultimately served in an iframe on another page,
+              // this document has a click handler that sends document's height to other window,
+              // which can then set the embedded iframe's height (see public/post-message.js)
+              document.querySelector('html')?.click();
+            }}
+          />
+
+          <EquivalentHomesText hourlyEere={hourlyEere} />
+
+          {!hardValid && (
+            <ValidationMessage
+              type="error"
+              value={hardTopExceedanceValue}
+              timestamp={hardTopExceedanceTimestamp}
+            />
+          )}
+
+          {hardValid && !softValid && (
+            <ValidationMessage
+              type="warning"
+              value={softTopExceedanceValue}
+              timestamp={softTopExceedanceTimestamp}
+            />
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/app/components/EEREChart.tsx
+++ b/client/src/app/components/EEREChart.tsx
@@ -21,6 +21,9 @@ function EquivalentHomesText(props: { hourlyEere: number[] }) {
    */
   const equivalentHomes = Math.round((totalLoadMwh / 12_146) * -1_000);
 
+  // TODO: determine which message to display for an increased load from EVs
+  if (totalLoadGwh < 0) return null;
+
   return (
     <p className="margin-top-2 text-base-dark">
       This EE/RE profile will displace{' '}

--- a/client/src/app/components/EEREChart.tsx
+++ b/client/src/app/components/EEREChart.tsx
@@ -98,6 +98,73 @@ function ValidationMessage(props: {
   );
 }
 
+export function EVWarningMessage() {
+  const constantMwh = useTypedSelector(({ eere }) => eere.inputs.constantMwh);
+  const annualGwh = useTypedSelector(({ eere }) => eere.inputs.annualGwh);
+  const broadProgram = useTypedSelector(({ eere }) => eere.inputs.broadProgram);
+  const reduction = useTypedSelector(({ eere }) => eere.inputs.reduction);
+  const topHours = useTypedSelector(({ eere }) => eere.inputs.topHours);
+  const onshoreWind = useTypedSelector(({ eere }) => eere.inputs.onshoreWind);
+  const offshoreWind = useTypedSelector(({ eere }) => eere.inputs.offshoreWind);
+  const utilitySolar = useTypedSelector(({ eere }) => eere.inputs.utilitySolar);
+  const rooftopSolar = useTypedSelector(({ eere }) => eere.inputs.rooftopSolar);
+  const batteryEVs = useTypedSelector(({ eere }) => eere.inputs.batteryEVs);
+  const hybridEVs = useTypedSelector(({ eere }) => eere.inputs.hybridEVs);
+  const transitBuses = useTypedSelector(({ eere }) => eere.inputs.transitBuses);
+  const schoolBuses = useTypedSelector(({ eere }) => eere.inputs.schoolBuses);
+
+  const eeInputsEmpty =
+    constantMwh === '' &&
+    annualGwh === '' &&
+    broadProgram === '' &&
+    reduction === '' &&
+    topHours === '';
+
+  const reInputsEmpty =
+    onshoreWind === '' &&
+    offshoreWind === '' &&
+    utilitySolar === '' &&
+    rooftopSolar === '';
+
+  const evInputsEmpty =
+    batteryEVs === '' &&
+    hybridEVs === '' &&
+    transitBuses === '' &&
+    schoolBuses === '';
+
+  if (eeInputsEmpty && reInputsEmpty && !evInputsEmpty) {
+    return (
+      <div className="usa-alert usa-alert--warning">
+        <div className="usa-alert__body">
+          <h4 className="usa-alert__heading">WARNING</h4>
+          <p>
+            <strong>
+              You have entered a quantity of EVs, but have not entered any
+              energy efficiency or renewable energy.
+            </strong>
+          </p>
+
+          <p>
+            Recent trends show significant amounts of energy efficiency and
+            renewables coming online. Consider adding these resources alongside
+            EVs in order to examine the portfolio effects of adding multiple
+            resources at the same time. The “EE/RE and EV Comparison” table
+            above summarizes recent historical ERE additions and compares these
+            with the EERE required to offset your entered EV demand.
+          </p>
+
+          <p>
+            For more ideas on how to model EVs in AVERT, see Appendix J in the
+            AVERT user manual.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
 function EEREChartContent() {
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
   const softValid = useTypedSelector(
@@ -235,6 +302,8 @@ function EEREChartContent() {
           />
 
           <EquivalentHomesText hourlyEere={hourlyEere} />
+
+          <EVWarningMessage />
 
           {!hardValid && (
             <ValidationMessage


### PR DESCRIPTION
Add EV warning message below EERE profile chart if Electric Vehicles inputs were entered, but no Energy Efficiency or Renewable Energy inputs were entered, and update logic around equivalent homes text to only display if the total load goes down (as it could not increase if EV inputs are entered without EE/RE inputs)