### PR TITLE
Feature/update download data

### DIFF
--- a/client/src/app/calculations/emissions.ts
+++ b/client/src/app/calculations/emissions.ts
@@ -1,6 +1,8 @@
-import { sortObjectByKeys } from 'app/calculations/utilities';
-import type { RegionId, StateId } from 'app/config';
 import type { RDFJSON } from 'app/redux/reducers/geography';
+import { sortObjectByKeys } from 'app/calculations/utilities';
+import type { VehicleEmissionChangesByGeography } from 'app/calculations/transportation';
+import type { RegionId, StateId } from 'app/config';
+
 /**
  * Annual point-source data from the National Emissions Inventory (NEI) for
  * every electric generating unit (EGU), organized by AVERT region
@@ -21,7 +23,7 @@ export type EmissionsData = {
     power: {
       monthly: EguData['data'][keyof EguData['data']];
       annual: { original: number; postEere: number };
-    };
+    } | null;
     vehicle: number | null;
   };
 };
@@ -388,25 +390,32 @@ export function calculateAggregatedEmissionsData(egus: EmissionsChanges) {
           const month = Number(monthlyKey);
           const { original, postEere } = monthlyData;
 
-          object.total[pollutant].power.monthly[month].original += original;
-          object.total[pollutant].power.monthly[month].postEere += postEere;
-          object.total[pollutant].power.annual.original += original;
-          object.total[pollutant].power.annual.postEere += postEere;
+          const powerTotal = object.total[pollutant].power;
+          const powerRegions = object.regions[regionId][pollutant].power;
+          const powerStates = object.states[stateId][pollutant].power;
+          const powerCounties = object.counties[stateId][county][pollutant].power; // prettier-ignore
 
-          object.regions[regionId][pollutant].power.monthly[month].original += original; // prettier-ignore
-          object.regions[regionId][pollutant].power.monthly[month].postEere += postEere; // prettier-ignore
-          object.regions[regionId][pollutant].power.annual.original += original;
-          object.regions[regionId][pollutant].power.annual.postEere += postEere;
+          if (powerTotal && powerRegions && powerStates && powerCounties) {
+            powerTotal.monthly[month].original += original;
+            powerTotal.monthly[month].postEere += postEere;
+            powerTotal.annual.original += original;
+            powerTotal.annual.postEere += postEere;
 
-          object.states[stateId][pollutant].power.monthly[month].original += original; // prettier-ignore
-          object.states[stateId][pollutant].power.monthly[month].postEere += postEere; // prettier-ignore
-          object.states[stateId][pollutant].power.annual.original += original;
-          object.states[stateId][pollutant].power.annual.postEere += postEere;
+            powerRegions.monthly[month].original += original;
+            powerRegions.monthly[month].postEere += postEere;
+            powerRegions.annual.original += original;
+            powerRegions.annual.postEere += postEere;
 
-          object.counties[stateId][county][pollutant].power.monthly[month].original += original; // prettier-ignore
-          object.counties[stateId][county][pollutant].power.monthly[month].postEere += postEere; // prettier-ignore
-          object.counties[stateId][county][pollutant].power.annual.original += original; // prettier-ignore
-          object.counties[stateId][county][pollutant].power.annual.postEere += postEere; // prettier-ignore
+            powerStates.monthly[month].original += original;
+            powerStates.monthly[month].postEere += postEere;
+            powerStates.annual.original += original;
+            powerStates.annual.postEere += postEere;
+
+            powerCounties.monthly[month].original += original;
+            powerCounties.monthly[month].postEere += postEere;
+            powerCounties.annual.original += original;
+            powerCounties.annual.postEere += postEere;
+          }
         });
       });
 

--- a/client/src/app/calculations/emissions.ts
+++ b/client/src/app/calculations/emissions.ts
@@ -459,6 +459,8 @@ export function createCombinedSectorsEmissionsData(options: {
   /** start with power sector emissions data */
   const result = { ...aggregatedEmissionsData };
 
+  /** TODO: add region (and total) level transportation sector emissions data */
+
   /** add state level transportation sector emissions data */
   Object.entries(vehicleEmissionChanges.states).forEach(([key, stateData]) => {
     const stateId = key as keyof typeof vehicleEmissionChanges.counties;

--- a/client/src/app/calculations/emissions.ts
+++ b/client/src/app/calculations/emissions.ts
@@ -454,7 +454,7 @@ export function createCombinedSectorsEmissionsData(options: {
       ? (vehicleEmissionChangesByGeography as VehicleEmissionChangesByGeography)
       : null;
 
-  if (!aggregatedEmissionsData || !vehicleEmissionChanges) return {};
+  if (!aggregatedEmissionsData || !vehicleEmissionChanges) return null;
 
   /** start with power sector emissions data */
   const result = { ...aggregatedEmissionsData };

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -21,7 +21,7 @@ import {
 } from 'app/redux/reducers/monthlyEmissions';
 import type {
   EmissionsData,
-  AggregatedEmissionsData,
+  CombinedSectorsEmissionsData,
 } from 'app/calculations/emissions';
 import { useSelectedRegion, useSelectedStateRegions } from 'app/hooks';
 import type { Pollutant, RegionId, StateId } from 'app/config';
@@ -501,20 +501,25 @@ function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
  * Sets emissions data based on the currently selected filters.
  */
 function setFilteredData(options: {
-  aggregatedEmissionsData: AggregatedEmissionsData;
+  combinedSectorsEmissionsData: CombinedSectorsEmissionsData;
   aggregation: Aggregation;
   regionId: RegionId | 'ALL';
   stateId: StateId;
   county: string;
 }) {
-  const { aggregatedEmissionsData, aggregation, regionId, stateId, county } =
-    options;
+  const {
+    combinedSectorsEmissionsData,
+    aggregation,
+    regionId,
+    stateId,
+    county,
+  } = options;
 
   const emptyResult = {} as EmissionsData;
 
-  if (!aggregatedEmissionsData) return emptyResult;
+  if (!combinedSectorsEmissionsData) return emptyResult;
 
-  const { total, regions, states, counties } = aggregatedEmissionsData;
+  const { total, regions, states, counties } = combinedSectorsEmissionsData;
 
   const regionResult =
     regionId === 'ALL'
@@ -546,8 +551,8 @@ function setFilteredData(options: {
 function MonthlyEmissionsChartsContent() {
   const dispatch = useDispatch();
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
-  const aggregatedEmissionsData = useTypedSelector(
-    ({ results }) => results.aggregatedEmissionsData,
+  const combinedSectorsEmissionsData = useTypedSelector(
+    ({ results }) => results.combinedSectorsEmissionsData,
   );
   const currentAggregation = useTypedSelector(
     ({ monthlyEmissions }) => monthlyEmissions.aggregation,
@@ -588,7 +593,7 @@ function MonthlyEmissionsChartsContent() {
       : (currentRegionId as RegionId);
 
   const data = setFilteredData({
-    aggregatedEmissionsData,
+    combinedSectorsEmissionsData,
     aggregation: currentAggregation,
     regionId,
     stateId: currentStateId as StateId,
@@ -1084,7 +1089,7 @@ function MonthlyEmissionsChartsContent() {
       </div>
 
       <div data-avert-charts>
-        {aggregatedEmissionsData && (
+        {combinedSectorsEmissionsData && (
           <div className="grid-container padding-0 maxw-full">
             <div className="grid-row" style={{ margin: '0 -0.5rem' }}>
               {geographicFocus === 'states' &&

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -6,10 +6,6 @@ import { useDispatch } from 'react-redux';
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { useTypedSelector } from 'app/redux/index';
 import type {
-  EmissionsData,
-  AggregatedEmissionsData,
-} from 'app/redux/reducers/results';
-import type {
   Aggregation,
   Source,
   Unit,
@@ -23,6 +19,10 @@ import {
   setMonthlyEmissionsSource,
   setMonthlyEmissionsUnit,
 } from 'app/redux/reducers/monthlyEmissions';
+import type {
+  EmissionsData,
+  AggregatedEmissionsData,
+} from 'app/calculations/emissions';
 import { useSelectedRegion, useSelectedStateRegions } from 'app/hooks';
 import type { Pollutant, RegionId, StateId } from 'app/config';
 import { regions, states } from 'app/config';

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -42,7 +42,7 @@ type ChartData = {
  * changes, for display in the monthly charts.
  */
 function calculateMonthlyData(
-  monthlyData: EmissionsData[keyof EmissionsData],
+  monthlyData: EmissionsData[keyof EmissionsData]['power']['monthly'],
   unit: Unit,
 ) {
   const monthlyEmissionsChanges: number[] = [];
@@ -93,16 +93,8 @@ function setChartSeriesData(options: {
   return result;
 }
 
-function Chart(props: {
-  pollutant: Pollutant;
-  powerData: {
-    [key in Pollutant]: {
-      monthly: EmissionsData[keyof EmissionsData];
-      annual: { original: 0; postEere: 0 };
-    };
-  };
-}) {
-  const { pollutant, powerData } = props;
+function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
+  const { pollutant, data } = props;
 
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
   const totalMonthlyEmissionChanges = useTypedSelector(
@@ -157,12 +149,12 @@ function Chart(props: {
     },
   );
 
-  // console.log({ powerData, vehicleEmissions }); // NOTE: for debugging purposes
+  // console.log({ data, vehicleEmissions }); // NOTE: for debugging purposes
 
   const so2Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(powerData.so2.monthly, currentUnit),
+      data: calculateMonthlyData(data.so2.power.monthly, currentUnit),
       color: 'rgba(5, 141, 199, 1)',
       unit: 'lb',
     },
@@ -177,7 +169,7 @@ function Chart(props: {
   const noxData = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(powerData.nox.monthly, currentUnit),
+      data: calculateMonthlyData(data.nox.power.monthly, currentUnit),
       color: 'rgba(237, 86, 27, 1)',
       unit: 'lb',
     },
@@ -192,7 +184,7 @@ function Chart(props: {
   const co2Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(powerData.co2.monthly, currentUnit),
+      data: calculateMonthlyData(data.co2.power.monthly, currentUnit),
       color: 'rgba(80, 180, 50, 1)',
       unit: 'tons',
     },
@@ -207,7 +199,7 @@ function Chart(props: {
   const pm25Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(powerData.pm25.monthly, currentUnit),
+      data: calculateMonthlyData(data.pm25.power.monthly, currentUnit),
       color: 'rgba(102, 86, 131, 1)',
       unit: 'lb',
     },
@@ -222,7 +214,7 @@ function Chart(props: {
   const vocsData = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(powerData.vocs.monthly, currentUnit),
+      data: calculateMonthlyData(data.vocs.power.monthly, currentUnit),
       color: 'rgba(255, 193, 7, 1)',
       unit: 'lb',
     },
@@ -237,7 +229,7 @@ function Chart(props: {
   const nh3Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(powerData.nh3.monthly, currentUnit),
+      data: calculateMonthlyData(data.nh3.power.monthly, currentUnit),
       color: 'rgba(0, 150, 136, 1)',
       unit: 'lb',
     },
@@ -503,9 +495,9 @@ function Chart(props: {
 }
 
 /**
- * Sets the power sector emissions data based on the currently selected filters.
+ * Sets emissions data based on the currently selected filters.
  */
-function setFilteredPowerData(options: {
+function setFilteredData(options: {
   aggregatedEmissionsData: AggregatedEmissionsData;
   aggregation: Aggregation;
   regionId: RegionId | 'ALL';
@@ -515,12 +507,7 @@ function setFilteredPowerData(options: {
   const { aggregatedEmissionsData, aggregation, regionId, stateId, county } =
     options;
 
-  const emptyResult = {} as {
-    [key in Pollutant]: {
-      monthly: EmissionsData[keyof EmissionsData];
-      annual: { original: 0; postEere: 0 };
-    };
-  };
+  const emptyResult = {} as EmissionsData;
 
   if (!aggregatedEmissionsData) return emptyResult;
 
@@ -597,7 +584,7 @@ function MonthlyEmissionsChartsContent() {
       ? selectedStateRegions[0].id
       : (currentRegionId as RegionId);
 
-  const powerData = setFilteredPowerData({
+  const data = setFilteredData({
     aggregatedEmissionsData,
     aggregation: currentAggregation,
     regionId,
@@ -1192,11 +1179,7 @@ function MonthlyEmissionsChartsContent() {
 
                   return (
                     <div key={pollutant} className={className}>
-                      <Chart
-                        key={key}
-                        pollutant={pollutant}
-                        powerData={powerData}
-                      />
+                      <Chart key={key} pollutant={pollutant} data={data} />
                     </div>
                   );
                 })

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -38,19 +38,22 @@ type ChartData = {
 };
 
 /**
- * Creates monthly emissions data for either emissions changes or percentage
- * changes, for display in the monthly charts.
+ * Creates monthly power sector emissions data for either emissions changes or
+ * percentage changes, for display in the monthly charts.
  */
-function calculateMonthlyData(
-  monthlyData: EmissionsData[keyof EmissionsData]['power']['monthly'],
+function calculateMonthlyPowerData(
+  data: EmissionsData[keyof EmissionsData],
   unit: Unit,
 ) {
   const monthlyEmissionsChanges: number[] = [];
   const monthlyPercentageChanges: number[] = [];
 
-  for (const dataKey in monthlyData) {
-    const month = Number(dataKey);
-    const { original, postEere } = monthlyData[month];
+  const powerData = data.power;
+  if (!powerData) return [];
+
+  for (const key in powerData.monthly) {
+    const month = Number(key);
+    const { original, postEere } = powerData.monthly[month];
 
     const emissionsChange = postEere - original;
     const percentChange = (emissionsChange / original) * 100 || 0;
@@ -154,7 +157,7 @@ function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
   const so2Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(data.so2.power.monthly, currentUnit),
+      data: calculateMonthlyPowerData(data.so2, currentUnit),
       color: 'rgba(5, 141, 199, 1)',
       unit: 'lb',
     },
@@ -169,7 +172,7 @@ function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
   const noxData = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(data.nox.power.monthly, currentUnit),
+      data: calculateMonthlyPowerData(data.nox, currentUnit),
       color: 'rgba(237, 86, 27, 1)',
       unit: 'lb',
     },
@@ -184,7 +187,7 @@ function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
   const co2Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(data.co2.power.monthly, currentUnit),
+      data: calculateMonthlyPowerData(data.co2, currentUnit),
       color: 'rgba(80, 180, 50, 1)',
       unit: 'tons',
     },
@@ -199,7 +202,7 @@ function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
   const pm25Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(data.pm25.power.monthly, currentUnit),
+      data: calculateMonthlyPowerData(data.pm25, currentUnit),
       color: 'rgba(102, 86, 131, 1)',
       unit: 'lb',
     },
@@ -214,7 +217,7 @@ function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
   const vocsData = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(data.vocs.power.monthly, currentUnit),
+      data: calculateMonthlyPowerData(data.vocs, currentUnit),
       color: 'rgba(255, 193, 7, 1)',
       unit: 'lb',
     },
@@ -229,7 +232,7 @@ function Chart(props: { pollutant: Pollutant; data: EmissionsData }) {
   const nh3Data = {
     power: {
       name: 'Power Sector',
-      data: calculateMonthlyData(data.nh3.power.monthly, currentUnit),
+      data: calculateMonthlyPowerData(data.nh3, currentUnit),
       color: 'rgba(0, 150, 136, 1)',
       unit: 'lb',
     },

--- a/client/src/app/components/PowerSectorEmissionsTable.tsx
+++ b/client/src/app/components/PowerSectorEmissionsTable.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { Tooltip } from 'app/components/Tooltip';
 import { useTypedSelector } from 'app/redux/index';
 import type { EmissionsReplacements } from 'app/redux/reducers/results';
-import type { AggregatedEmissionsData } from 'app/calculations/emissions';
+import type { CombinedSectorsEmissionsData } from 'app/calculations/emissions';
 
 type AnnualMonthlyData = ReturnType<typeof setAnnualMonthlyData>;
 
@@ -23,9 +23,9 @@ function formatNumber(number: number) {
  * we might as well build up every field from their monthly values.
  */
 function setAnnualMonthlyData(
-  aggregatedEmissionsData: AggregatedEmissionsData,
+  combinedSectorsEmissionsData: CombinedSectorsEmissionsData,
 ) {
-  if (!aggregatedEmissionsData) {
+  if (!combinedSectorsEmissionsData) {
     return {
       generation: { original: 0, postEere: 0, impacts: 0 },
       ozoneGeneration: { original: 0, postEere: 0, impacts: 0 },
@@ -39,9 +39,9 @@ function setAnnualMonthlyData(
     };
   }
 
-  const result = Object.entries(aggregatedEmissionsData.total).reduce(
+  const result = Object.entries(combinedSectorsEmissionsData.total).reduce(
     (object, [key, value]) => {
-      const field = key as keyof typeof aggregatedEmissionsData.total;
+      const field = key as keyof typeof combinedSectorsEmissionsData.total;
       const totalPowerData = value.power;
 
       if (totalPowerData) {
@@ -151,14 +151,14 @@ function EmissionsReplacementTooltip(props: {
 }
 
 function PowerSectorEmissionsTableContent() {
-  const aggregatedEmissionsData = useTypedSelector(
-    ({ results }) => results.aggregatedEmissionsData,
+  const combinedSectorsEmissionsData = useTypedSelector(
+    ({ results }) => results.combinedSectorsEmissionsData,
   );
   const emissionsReplacements = useTypedSelector(
     ({ results }) => results.emissionsReplacements,
   );
 
-  const annualMonthlyData = setAnnualMonthlyData(aggregatedEmissionsData);
+  const annualMonthlyData = setAnnualMonthlyData(combinedSectorsEmissionsData);
 
   const data = applyEmissionsReplacement({
     annualMonthlyData,
@@ -177,7 +177,7 @@ function PowerSectorEmissionsTableContent() {
     nh3,
   } = data;
 
-  if (!aggregatedEmissionsData) return null;
+  if (!combinedSectorsEmissionsData) return null;
 
   return (
     <>

--- a/client/src/app/components/PowerSectorEmissionsTable.tsx
+++ b/client/src/app/components/PowerSectorEmissionsTable.tsx
@@ -42,35 +42,38 @@ function setAnnualMonthlyData(
   const result = Object.entries(aggregatedEmissionsData.total).reduce(
     (object, [key, value]) => {
       const field = key as keyof typeof aggregatedEmissionsData.total;
+      const totalPowerData = value.power;
 
-      Object.entries(value.power.monthly).forEach(
-        ([monthlyKey, monthlyData]) => {
-          const month = Number(monthlyKey);
-          const { original, postEere } = monthlyData;
+      if (totalPowerData) {
+        Object.entries(totalPowerData.monthly).forEach(
+          ([monthlyKey, monthlyData]) => {
+            const month = Number(monthlyKey);
+            const { original, postEere } = monthlyData;
 
-          /**
-           * Build up ozone season generation and ozone season nox
-           * (Ozone season is between May and September)
-           */
-          if (month >= 5 && month <= 9) {
-            if (field === 'generation') {
-              object.ozoneGeneration.original += original;
-              object.ozoneGeneration.postEere += postEere;
-              object.ozoneGeneration.impacts += postEere - original;
+            /**
+             * Build up ozone season generation and ozone season nox
+             * (Ozone season is between May and September)
+             */
+            if (month >= 5 && month <= 9) {
+              if (field === 'generation') {
+                object.ozoneGeneration.original += original;
+                object.ozoneGeneration.postEere += postEere;
+                object.ozoneGeneration.impacts += postEere - original;
+              }
+
+              if (field === 'nox') {
+                object.ozoneNox.original += original;
+                object.ozoneNox.postEere += postEere;
+                object.ozoneNox.impacts += postEere - original;
+              }
             }
 
-            if (field === 'nox') {
-              object.ozoneNox.original += original;
-              object.ozoneNox.postEere += postEere;
-              object.ozoneNox.impacts += postEere - original;
-            }
-          }
-
-          object[field].original += original;
-          object[field].postEere += postEere;
-          object[field].impacts += postEere - original;
-        },
-      );
+            object[field].original += original;
+            object[field].postEere += postEere;
+            object[field].impacts += postEere - original;
+          },
+        );
+      }
 
       return object;
     },

--- a/client/src/app/components/PowerSectorEmissionsTable.tsx
+++ b/client/src/app/components/PowerSectorEmissionsTable.tsx
@@ -3,10 +3,8 @@ import { ReactNode } from 'react';
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { Tooltip } from 'app/components/Tooltip';
 import { useTypedSelector } from 'app/redux/index';
-import type {
-  AggregatedEmissionsData,
-  EmissionsReplacements,
-} from 'app/redux/reducers/results';
+import type { EmissionsReplacements } from 'app/redux/reducers/results';
+import type { AggregatedEmissionsData } from 'app/calculations/emissions';
 
 type AnnualMonthlyData = ReturnType<typeof setAnnualMonthlyData>;
 

--- a/client/src/app/components/PowerSectorEmissionsTable.tsx
+++ b/client/src/app/components/PowerSectorEmissionsTable.tsx
@@ -45,32 +45,34 @@ function setAnnualMonthlyData(
     (object, [key, value]) => {
       const field = key as keyof typeof aggregatedEmissionsData.total;
 
-      Object.entries(value.monthly).forEach(([monthlyKey, monthlyData]) => {
-        const month = Number(monthlyKey);
-        const { original, postEere } = monthlyData;
+      Object.entries(value.power.monthly).forEach(
+        ([monthlyKey, monthlyData]) => {
+          const month = Number(monthlyKey);
+          const { original, postEere } = monthlyData;
 
-        /**
-         * Build up ozone season generation and ozone season nox
-         * (Ozone season is between May and September)
-         */
-        if (month >= 5 && month <= 9) {
-          if (field === 'generation') {
-            object.ozoneGeneration.original += original;
-            object.ozoneGeneration.postEere += postEere;
-            object.ozoneGeneration.impacts += postEere - original;
+          /**
+           * Build up ozone season generation and ozone season nox
+           * (Ozone season is between May and September)
+           */
+          if (month >= 5 && month <= 9) {
+            if (field === 'generation') {
+              object.ozoneGeneration.original += original;
+              object.ozoneGeneration.postEere += postEere;
+              object.ozoneGeneration.impacts += postEere - original;
+            }
+
+            if (field === 'nox') {
+              object.ozoneNox.original += original;
+              object.ozoneNox.postEere += postEere;
+              object.ozoneNox.impacts += postEere - original;
+            }
           }
 
-          if (field === 'nox') {
-            object.ozoneNox.original += original;
-            object.ozoneNox.postEere += postEere;
-            object.ozoneNox.impacts += postEere - original;
-          }
-        }
-
-        object[field].original += original;
-        object[field].postEere += postEere;
-        object[field].impacts += postEere - original;
-      });
+          object[field].original += original;
+          object[field].postEere += postEere;
+          object[field].impacts += postEere - original;
+        },
+      );
 
       return object;
     },

--- a/client/src/app/components/StateEmissionsTable.tsx
+++ b/client/src/app/components/StateEmissionsTable.tsx
@@ -36,13 +36,15 @@ function setAnnualStateEmissionsChanges(
           const statePowerData = stateDataValue.power;
           const stateVehicleData = stateDataValue.vehicle;
 
-          if (pollutant !== 'generation' && statePowerData) {
-            const { original, postEere } = statePowerData.annual;
-            object.power[pollutant] += postEere - original;
-          }
+          if (pollutant !== 'generation') {
+            if (statePowerData !== null) {
+              const { original, postEere } = statePowerData.annual;
+              object.power[pollutant] += postEere - original;
+            }
 
-          if (pollutant !== 'generation' && stateVehicleData) {
-            object.vehicle[pollutant] = stateVehicleData;
+            if (stateVehicleData !== null) {
+              object.vehicle[pollutant] = stateVehicleData;
+            }
           }
 
           return object;

--- a/client/src/app/components/StateEmissionsTable.tsx
+++ b/client/src/app/components/StateEmissionsTable.tsx
@@ -57,14 +57,19 @@ function setAnnualStateEmissionsChanges(options: {
 
   /** Add power sector data */
   Object.entries(aggregatedEmissionsData.states).forEach(([key, stateData]) => {
-    const stateId = key as StateId;
+    const stateId = key as keyof typeof aggregatedEmissionsData.states;
     const stateName = statesConfig[stateId].name;
 
     const power = Object.entries(stateData).reduce(
       (object, [stateDataKey, stateDataValue]) => {
         const pollutant = stateDataKey as keyof typeof stateData;
-        const { original, postEere } = stateDataValue.power.annual;
-        object[pollutant] += postEere - original;
+        const statePowerData = stateDataValue.power;
+
+        if (statePowerData) {
+          const { original, postEere } = statePowerData.annual;
+          object[pollutant] += postEere - original;
+        }
+
         return object;
       },
       { generation: 0, so2: 0, nox: 0, co2: 0, pm25: 0, vocs: 0, nh3: 0 },

--- a/client/src/app/components/StateEmissionsTable.tsx
+++ b/client/src/app/components/StateEmissionsTable.tsx
@@ -63,7 +63,7 @@ function setAnnualStateEmissionsChanges(options: {
     const power = Object.entries(stateData).reduce(
       (object, [stateDataKey, stateDataValue]) => {
         const pollutant = stateDataKey as keyof typeof stateData;
-        const { original, postEere } = stateDataValue.annual;
+        const { original, postEere } = stateDataValue.power.annual;
         object[pollutant] += postEere - original;
         return object;
       },

--- a/client/src/app/components/StateEmissionsTable.tsx
+++ b/client/src/app/components/StateEmissionsTable.tsx
@@ -2,8 +2,8 @@ import { Fragment } from 'react';
 // ---
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { useTypedSelector } from 'app/redux/index';
-import type { AggregatedEmissionsData } from 'app/redux/reducers/results';
 import type { VehicleEmissionChangesByGeography } from 'app/calculations/transportation';
+import type { AggregatedEmissionsData } from 'app/calculations/emissions';
 import type { StateId } from 'app/config';
 import { states as statesConfig } from 'app/config';
 

--- a/client/src/app/components/TransportationSectorEmissionsTable.tsx
+++ b/client/src/app/components/TransportationSectorEmissionsTable.tsx
@@ -1,6 +1,6 @@
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { useTypedSelector } from 'app/redux/index';
-import type { AggregatedEmissionsData } from 'app/calculations/emissions';
+import type { CombinedSectorsEmissionsData } from 'app/calculations/emissions';
 
 /**
  * Round number to the nearest 10 and conditionally display '--' if number is
@@ -16,15 +16,15 @@ function formatNumber(number: number) {
  * Calculate the annual emissions changes for each pollutant.
  */
 function setAnnualEmissionsChanges(
-  aggregatedEmissionsData: AggregatedEmissionsData,
+  combinedSectorsEmissionsData: CombinedSectorsEmissionsData,
 ) {
-  if (!aggregatedEmissionsData) {
+  if (!combinedSectorsEmissionsData) {
     return { generation: 0, so2: 0, nox: 0, co2: 0, pm25: 0, vocs: 0, nh3: 0 };
   }
 
-  const result = Object.entries(aggregatedEmissionsData.total).reduce(
+  const result = Object.entries(combinedSectorsEmissionsData.total).reduce(
     (object, [key, value]) => {
-      const pollutant = key as keyof typeof aggregatedEmissionsData.total;
+      const pollutant = key as keyof typeof combinedSectorsEmissionsData.total;
       const totalPowerData = value.power;
 
       if (totalPowerData) {
@@ -44,12 +44,12 @@ function TransportationSectorEmissionsTableContent() {
   const totalYearlyVehicleEmissionsChanges = useTypedSelector(
     ({ transportation }) => transportation.totalYearlyEmissionChanges,
   );
-  const aggregatedEmissionsData = useTypedSelector(
-    ({ results }) => results.aggregatedEmissionsData,
+  const combinedSectorsEmissionsData = useTypedSelector(
+    ({ results }) => results.combinedSectorsEmissionsData,
   );
 
   const annualEmissionsChanges = setAnnualEmissionsChanges(
-    aggregatedEmissionsData,
+    combinedSectorsEmissionsData,
   );
 
   const annualVehicleSO2 = -1 * totalYearlyVehicleEmissionsChanges.total.SO2;
@@ -66,7 +66,7 @@ function TransportationSectorEmissionsTableContent() {
   const annualPowerVOCs = annualEmissionsChanges.vocs;
   const annualPowerNH3 = annualEmissionsChanges.nh3;
 
-  if (!aggregatedEmissionsData) return null;
+  if (!combinedSectorsEmissionsData) return null;
 
   return (
     <>

--- a/client/src/app/components/TransportationSectorEmissionsTable.tsx
+++ b/client/src/app/components/TransportationSectorEmissionsTable.tsx
@@ -25,8 +25,13 @@ function setAnnualEmissionsChanges(
   const result = Object.entries(aggregatedEmissionsData.total).reduce(
     (object, [key, value]) => {
       const pollutant = key as keyof typeof aggregatedEmissionsData.total;
-      const { original, postEere } = value.power.annual;
-      object[pollutant] += postEere - original;
+      const totalPowerData = value.power;
+
+      if (totalPowerData) {
+        const { original, postEere } = totalPowerData.annual;
+        object[pollutant] += postEere - original;
+      }
+
       return object;
     },
     { generation: 0, so2: 0, nox: 0, co2: 0, pm25: 0, vocs: 0, nh3: 0 },

--- a/client/src/app/components/TransportationSectorEmissionsTable.tsx
+++ b/client/src/app/components/TransportationSectorEmissionsTable.tsx
@@ -1,6 +1,6 @@
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { useTypedSelector } from 'app/redux/index';
-import type { AggregatedEmissionsData } from 'app/redux/reducers/results';
+import type { AggregatedEmissionsData } from 'app/calculations/emissions';
 
 /**
  * Round number to the nearest 10 and conditionally display '--' if number is

--- a/client/src/app/components/TransportationSectorEmissionsTable.tsx
+++ b/client/src/app/components/TransportationSectorEmissionsTable.tsx
@@ -25,7 +25,7 @@ function setAnnualEmissionsChanges(
   const result = Object.entries(aggregatedEmissionsData.total).reduce(
     (object, [key, value]) => {
       const pollutant = key as keyof typeof aggregatedEmissionsData.total;
-      const { original, postEere } = value.annual;
+      const { original, postEere } = value.power.annual;
       object[pollutant] += postEere - original;
       return object;
     },

--- a/client/src/app/redux/reducers/downloads.ts
+++ b/client/src/app/redux/reducers/downloads.ts
@@ -36,6 +36,7 @@ type CountyData = {
   'Power Sector: October': number | null;
   'Power Sector: November': number | null;
   'Power Sector: December': number | null;
+  'Power Sector: Annual': number | null;
 };
 
 type CobraData = {
@@ -330,6 +331,19 @@ function createMonthlyEmissionsDataFields(options: {
 }) {
   const { pollutantNeedsReplacement, monthlyData, unit } = options;
 
+  /** annual totals */
+  const total = Object.values(monthlyData).reduce(
+    (object, data) => {
+      object.original += data.original;
+      object.postEere += data.postEere;
+      return object;
+    },
+    { original: 0, postEere: 0 },
+  );
+
+  const totalEmissionsChange = total.postEere - total.original;
+  const totalPercentChange = (totalEmissionsChange / total.original) * 100 || 0;
+
   const result = Object.entries(monthlyData).reduce((object, [key, data]) => {
     const month = Number(key);
     const { original, postEere } = data;
@@ -360,6 +374,8 @@ function createMonthlyEmissionsDataFields(options: {
     'Power Sector: October': result[10],
     'Power Sector: November': result[11],
     'Power Sector: December': result[12],
+    'Power Sector: Annual':
+      unit === 'percent' ? totalPercentChange : totalEmissionsChange,
   };
 }
 

--- a/client/src/app/redux/reducers/downloads.ts
+++ b/client/src/app/redux/reducers/downloads.ts
@@ -1,11 +1,11 @@
 import type { AppThunk } from 'app/redux/index';
+import type { EgusNeeingEmissionsReplacement } from 'app/redux/reducers/results';
 import type { VehicleEmissionChangesByGeography } from 'app/calculations/transportation';
 import type {
   EmissionsData,
   EmissionsFlagsField,
   AggregatedEmissionsData,
-  EgusNeeingEmissionsReplacement,
-} from 'app/redux/reducers/results';
+} from 'app/calculations/emissions';
 import type { RegionId } from 'app/config';
 import { regions as regionsConfig, states as statesConfig } from 'app/config';
 /**

--- a/client/src/app/redux/reducers/results.ts
+++ b/client/src/app/redux/reducers/results.ts
@@ -1,27 +1,15 @@
 import type { AppThunk } from 'app/redux/index';
 import { setStatesAndCounties } from 'app/redux/reducers/monthlyEmissions';
 import { setDownloadData } from 'app/redux/reducers/downloads';
-import { sortObjectByKeys } from 'app/calculations/utilities';
-import type { EmissionsChanges } from 'app/calculations/emissions';
-import type { RegionId, StateId } from 'app/config';
+import { calculateAggregatedEmissionsData } from 'app/calculations/emissions';
+import type {
+  EmissionsChanges,
+  EmissionsFlagsField,
+  AggregatedEmissionsData,
+} from 'app/calculations/emissions';
+import type { RegionId } from 'app/config';
 import { regions } from 'app/config';
 
-const emissionsFields = ["generation", "so2", "nox", "co2", "pm25", "vocs", "nh3"] as const; // prettier-ignore
-
-type EguData = EmissionsChanges[string];
-export type EmissionsFlagsField = EguData['emissionsFlags'][number];
-export type EmissionsData = {
-  [field in typeof emissionsFields[number]]: {
-    power: {
-      monthly: EguData['data'][keyof EguData['data']];
-      annual: { original: number; postEere: number };
-    };
-    vehicle: number | null;
-  };
-};
-export type AggregatedEmissionsData = ReturnType<
-  typeof calculateAggregatedEmissionsData
->;
 export type EgusNeeingEmissionsReplacement = ReturnType<typeof setEgusNeedingEmissionsReplacement>; // prettier-ignore
 export type EmissionsReplacements = ReturnType<typeof setEmissionsReplacements>;
 
@@ -224,109 +212,6 @@ export function fetchEmissionsChanges(): AppThunk {
         dispatch({ type: 'results/FETCH_EMISSIONS_CHANGES_FAILURE' });
       });
   };
-}
-
-/**
- * Creates the intial structure of monthly and annual emissions data for each
- * pollutant.
- */
-function createInitialEmissionsData() {
-  const result = emissionsFields.reduce((object, field) => {
-    const monthlyData = [...Array(12)].reduce((data, _item, index) => {
-      const month = index + 1;
-      data[month] = { original: 0, postEere: 0 };
-      return data;
-    }, {} as EguData['data'][keyof EguData['data']]);
-
-    object[field] = {
-      power: {
-        monthly: monthlyData,
-        annual: { original: 0, postEere: 0 },
-      },
-      vehicle: null,
-    };
-
-    return object;
-  }, {} as EmissionsData);
-
-  return result;
-}
-
-/**
- * Sum the provided EGUs emissions data into monthly and annual original and
- * post-EERE values for each pollutant.
- */
-function calculateAggregatedEmissionsData(egus: EmissionsChanges) {
-  if (Object.keys(egus).length === 0) return null;
-
-  const result = Object.values(egus).reduce(
-    (object, eguData) => {
-      const regionId = eguData.region as RegionId;
-      const stateId = eguData.state as StateId;
-      const county = eguData.county;
-
-      object.regions[regionId] ??= createInitialEmissionsData();
-      object.states[stateId] ??= createInitialEmissionsData();
-      object.counties[stateId] ??= {};
-      object.counties[stateId][county] ??= createInitialEmissionsData();
-
-      Object.entries(eguData.data).forEach(([annualKey, annualData]) => {
-        const pollutant = annualKey as keyof typeof eguData.data;
-
-        Object.entries(annualData).forEach(([monthlyKey, monthlyData]) => {
-          const month = Number(monthlyKey);
-          const { original, postEere } = monthlyData;
-
-          object.total[pollutant].power.monthly[month].original += original;
-          object.total[pollutant].power.monthly[month].postEere += postEere;
-          object.total[pollutant].power.annual.original += original;
-          object.total[pollutant].power.annual.postEere += postEere;
-
-          object.regions[regionId][pollutant].power.monthly[month].original += original; // prettier-ignore
-          object.regions[regionId][pollutant].power.monthly[month].postEere += postEere; // prettier-ignore
-          object.regions[regionId][pollutant].power.annual.original += original;
-          object.regions[regionId][pollutant].power.annual.postEere += postEere;
-
-          object.states[stateId][pollutant].power.monthly[month].original += original; // prettier-ignore
-          object.states[stateId][pollutant].power.monthly[month].postEere += postEere; // prettier-ignore
-          object.states[stateId][pollutant].power.annual.original += original;
-          object.states[stateId][pollutant].power.annual.postEere += postEere;
-
-          object.counties[stateId][county][pollutant].power.monthly[month].original += original; // prettier-ignore
-          object.counties[stateId][county][pollutant].power.monthly[month].postEere += postEere; // prettier-ignore
-          object.counties[stateId][county][pollutant].power.annual.original += original; // prettier-ignore
-          object.counties[stateId][county][pollutant].power.annual.postEere += postEere; // prettier-ignore
-        });
-      });
-
-      return object;
-    },
-    {
-      total: createInitialEmissionsData(),
-      regions: {},
-      states: {},
-      counties: {},
-    } as {
-      total: EmissionsData;
-      regions: { [regionId in RegionId]: EmissionsData };
-      states: { [stateId in StateId]: EmissionsData };
-      counties: { [stateId in StateId]: { [county: string]: EmissionsData } };
-    },
-  );
-
-  // sort results alphabetically
-  result.regions = sortObjectByKeys(result.regions);
-  result.states = sortObjectByKeys(result.states);
-  result.counties = sortObjectByKeys(result.counties);
-  result.counties = Object.entries(result.counties).reduce(
-    (object, [stateId, counties]) => {
-      object[stateId as StateId] = sortObjectByKeys(counties);
-      return object;
-    },
-    {} as typeof result.counties,
-  );
-
-  return result;
 }
 
 /**


### PR DESCRIPTION
Adds FIPS code to county level download data, adds transportation level data for counties and states, and stores emissions data combined from both power and transportation sectors for shared use across app (so individual components and/or reducers don't need to do that recombining when using/displaying data from both sectors).