### PR TITLE
Feature/improve transportation calculations performance

### DIFF
--- a/client/src/app/components/EEREChart.tsx
+++ b/client/src/app/components/EEREChart.tsx
@@ -11,9 +11,9 @@ require('highcharts/modules/accessibility')(Highcharts);
 
 function EEREChartContent() {
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
-  const inputs = useTypedSelector(({ eere }) => eere.inputs);
-  const calculationInputs = useTypedSelector(
-    ({ eere }) => eere.calculationInputs,
+  const eereInputs = useTypedSelector(({ eere }) => eere.inputs);
+  const eereProfileCalculationInputs = useTypedSelector(
+    ({ eere }) => eere.profileCalculationInputs,
   );
   const hourlyEere = useTypedSelector(
     ({ eere }) => eere.combinedProfile.hourlyEere,
@@ -23,12 +23,14 @@ function EEREChartContent() {
    * Recalculation of the EERE profile is needed if the EERE inputs have changed
    * from the ones used in the EERE profile calculation
    */
-  const eereProfileRecalculationNeeded = !Object.keys(inputs).every((field) => {
-    return (
-      inputs[field as keyof typeof inputs] ===
-      calculationInputs[field as keyof typeof calculationInputs]
-    );
-  });
+  const eereProfileRecalculationNeeded = !Object.keys(eereInputs).every(
+    (field) => {
+      return (
+        eereInputs[field as keyof typeof eereInputs] ===
+        eereProfileCalculationInputs[field as keyof typeof eereProfileCalculationInputs] // prettier-ignore
+      );
+    },
+  );
 
   const selectedRegion = useSelectedRegion();
   const selectedStateRegions = useSelectedStateRegions();

--- a/client/src/app/components/EEREInputs.tsx
+++ b/client/src/app/components/EEREInputs.tsx
@@ -70,8 +70,8 @@ const inputsSummaryStyles = css`
 function EEREInputsContent() {
   const dispatch = useDispatch();
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
-  const calculationStatus = useTypedSelector(
-    ({ eere }) => eere.calculationStatus,
+  const eereProfileCalculationStatus = useTypedSelector(
+    ({ eere }) => eere.profileCalculationStatus,
   );
   const errors = useTypedSelector(({ eere }) => eere.errors);
   const constantMwh = useTypedSelector(({ eere }) => eere.inputs.constantMwh);
@@ -145,10 +145,10 @@ function EEREInputsContent() {
   const textInputsAreEmpty =
     textInputsFields.filter((field) => field?.length > 0).length === 0;
 
-  const calculationDisabled =
+  const eereProfileCalculationDisabled =
     !textInputsAreValid ||
     textInputsAreEmpty ||
-    calculationStatus === 'pending';
+    eereProfileCalculationStatus === 'pending';
 
   const eereButtonOptions = {
     idle: 'Calculate EE/RE Impacts',
@@ -156,7 +156,7 @@ function EEREInputsContent() {
     success: 'Recalculate EE/RE Impacts',
   };
 
-  const disabledButtonClassName = calculationDisabled
+  const disabledButtonClassName = eereProfileCalculationDisabled
     ? 'avert-button-disabled'
     : '';
 
@@ -719,12 +719,12 @@ function EEREInputsContent() {
           href="/"
           onClick={(ev) => {
             ev.preventDefault();
-            if (calculationDisabled) return;
+            if (eereProfileCalculationDisabled) return;
             dispatch(calculateEereProfile());
           }}
           data-avert-calculate-impacts-btn
         >
-          {eereButtonOptions[calculationStatus]}
+          {eereButtonOptions[eereProfileCalculationStatus]}
         </a>
       </p>
     </>

--- a/client/src/app/components/EEREInputs.tsx
+++ b/client/src/app/components/EEREInputs.tsx
@@ -24,9 +24,13 @@ import {
   updateEereUtilitySolar,
   updateEereRooftopSolar,
   updateEereBatteryEVs,
+  runEereBatteryEVsCalculations,
   updateEereHybridEVs,
+  runEereHybridEVsCalculations,
   updateEereTransitBuses,
+  runEereTransitBusesCalculations,
   updateEereSchoolBuses,
+  runEereSchoolBusesCalculations,
   updateEereEVDeploymentLocation,
   updateEereEVModelYear,
   updateEereICEReplacementVehicle,
@@ -602,6 +606,9 @@ function EEREInputsContent() {
                             onChange={(text) =>
                               dispatch(updateEereBatteryEVs(text))
                             }
+                            onBlur={(text) =>
+                              dispatch(runEereBatteryEVsCalculations(text))
+                            }
                             tooltip={<p className="margin-0">TODO</p>}
                           />
                         </div>
@@ -615,6 +622,9 @@ function EEREInputsContent() {
                             fieldName="hybridEVs"
                             onChange={(text) =>
                               dispatch(updateEereHybridEVs(text))
+                            }
+                            onBlur={(text) =>
+                              dispatch(runEereHybridEVsCalculations(text))
                             }
                             tooltip={<p className="margin-0">TODO</p>}
                           />
@@ -632,6 +642,9 @@ function EEREInputsContent() {
                             onChange={(text) =>
                               dispatch(updateEereTransitBuses(text))
                             }
+                            onBlur={(text) =>
+                              dispatch(runEereTransitBusesCalculations(text))
+                            }
                             tooltip={<p className="margin-0">TODO</p>}
                           />
                         </div>
@@ -645,6 +658,9 @@ function EEREInputsContent() {
                             fieldName="schoolBuses"
                             onChange={(text) =>
                               dispatch(updateEereSchoolBuses(text))
+                            }
+                            onBlur={(text) =>
+                              dispatch(runEereSchoolBusesCalculations(text))
                             }
                             tooltip={<p className="margin-0">TODO</p>}
                           />

--- a/client/src/app/components/EERETextInput.tsx
+++ b/client/src/app/components/EERETextInput.tsx
@@ -81,7 +81,10 @@ export function EERETextInput(props: {
           onBlur={(ev) => onBlur && onBlur(ev.target.value)}
           onKeyPress={(ev) => {
             if (eereProfileCalculationDisabled) return;
-            if (ev.key === 'Enter') dispatch(calculateEereProfile());
+            if (ev.key === 'Enter') {
+              onBlur && onBlur((ev.target as HTMLInputElement).value);
+              dispatch(calculateEereProfile());
+            }
           }}
         />
 

--- a/client/src/app/components/EERETextInput.tsx
+++ b/client/src/app/components/EERETextInput.tsx
@@ -19,6 +19,7 @@ export function EERETextInput(props: {
   fieldName: string;
   disabled?: string;
   onChange: (value: string) => void;
+  onBlur?: (value: string) => void;
   tooltip?: ReactNode;
 }) {
   const {
@@ -30,6 +31,7 @@ export function EERETextInput(props: {
     fieldName,
     disabled,
     onChange,
+    onBlur,
     tooltip,
   } = props;
 
@@ -74,6 +76,7 @@ export function EERETextInput(props: {
           data-avert-eere-input={fieldName}
           disabled={Boolean(disabled)}
           onChange={(ev) => onChange(ev.target.value)}
+          onBlur={(ev) => onBlur && onBlur(ev.target.value)}
           onKeyPress={(ev) => {
             if (calculationDisabled) return;
             if (ev.key === 'Enter') dispatch(calculateEereProfile());

--- a/client/src/app/components/EERETextInput.tsx
+++ b/client/src/app/components/EERETextInput.tsx
@@ -36,16 +36,18 @@ export function EERETextInput(props: {
   } = props;
 
   const dispatch = useDispatch();
-  const calculationStatus = useTypedSelector(
-    ({ eere }) => eere.calculationStatus,
+  const eereProfileCalculationStatus = useTypedSelector(
+    ({ eere }) => eere.profileCalculationStatus,
   );
   const errors = useTypedSelector(({ eere }) => eere.errors);
 
   const inputsAreValid = errors.length === 0;
   const inputIsEmpty = value.length === 0;
 
-  const calculationDisabled =
-    !inputsAreValid || inputIsEmpty || calculationStatus === 'pending';
+  const eereProfileCalculationDisabled =
+    !inputsAreValid ||
+    inputIsEmpty ||
+    eereProfileCalculationStatus === 'pending';
 
   return (
     <div className={className ? className : ''}>
@@ -78,7 +80,7 @@ export function EERETextInput(props: {
           onChange={(ev) => onChange(ev.target.value)}
           onBlur={(ev) => onBlur && onBlur(ev.target.value)}
           onKeyPress={(ev) => {
-            if (calculationDisabled) return;
+            if (eereProfileCalculationDisabled) return;
             if (ev.key === 'Enter') dispatch(calculateEereProfile());
           }}
         />

--- a/client/src/app/components/PanelFooter.tsx
+++ b/client/src/app/components/PanelFooter.tsx
@@ -77,11 +77,11 @@ export function PanelFooter(props: {
   const activeStep = useTypedSelector(({ panel }) => panel.activeStep);
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
   const eereInputs = useTypedSelector(({ eere }) => eere.inputs);
-  const eereCalculationStatus = useTypedSelector(
-    ({ eere }) => eere.calculationStatus,
+  const eereProfileCalculationStatus = useTypedSelector(
+    ({ eere }) => eere.profileCalculationStatus,
   );
-  const eereCalculationInputs = useTypedSelector(
-    ({ eere }) => eere.calculationInputs,
+  const eereProfileCalculationInputs = useTypedSelector(
+    ({ eere }) => eere.profileCalculationInputs,
   );
   const eereHardValid = useTypedSelector(
     ({ eere }) => eere.combinedProfile.hardValid,
@@ -108,12 +108,12 @@ export function PanelFooter(props: {
     !Object.keys(eereInputs).every((field) => {
       return (
         eereInputs[field as keyof typeof eereInputs] ===
-        eereCalculationInputs[field as keyof typeof eereCalculationInputs]
+        eereProfileCalculationInputs[field as keyof typeof eereProfileCalculationInputs] // prettier-ignore
       );
     });
 
   const eereProfileCalculationNotComplete =
-    onStepTwo && eereCalculationStatus !== 'success';
+    onStepTwo && eereProfileCalculationStatus !== 'success';
 
   const eereProfileExceedsHardValidationLimit = onStepTwo && !eereHardValid;
 
@@ -164,7 +164,7 @@ export function PanelFooter(props: {
 
         if (onStepTwo) {
           if (
-            eereCalculationStatus === 'success' &&
+            eereProfileCalculationStatus === 'success' &&
             !eereProfileRecalculationNeeded &&
             eereHardValid
           ) {

--- a/client/src/app/redux/reducers/eere.ts
+++ b/client/src/app/redux/reducers/eere.ts
@@ -1212,11 +1212,9 @@ export function resetEEREInputs(): AppThunk {
 
     dispatch({ type: 'eere/RESET_EERE_INPUTS' });
 
-    // reset all EV inputs so dependant transportation calculations are re-run
-    dispatch(updateEereBatteryEVs(''));
-    dispatch(updateEereHybridEVs(''));
-    dispatch(updateEereTransitBuses(''));
-    dispatch(updateEereSchoolBuses(''));
+    // re-run dependant transportation calculations after resetting EV inputs
+    dispatch(setVehiclesDisplaced());
+
     dispatch(updateEereEVDeploymentLocation(evDeploymentLocation));
     dispatch(updateEereEVModelYear(evModelYear));
     dispatch(updateEereICEReplacementVehicle(iceReplacementVehicle));

--- a/client/src/app/redux/reducers/eere.ts
+++ b/client/src/app/redux/reducers/eere.ts
@@ -130,15 +130,15 @@ type EereAction =
       payload: { option: string };
     }
   | {
-      type: 'eere/START_EERE_CALCULATIONS';
-      payload: { calculationInputs: EEREInputs };
+      type: 'eere/START_EERE_PROFILE_CALCULATIONS';
+      payload: { profileCalculationInputs: EEREInputs };
     }
   | {
       type: 'eere/CALCULATE_REGIONAL_EERE_PROFILE';
       payload: RegionalProfile;
     }
   | {
-      type: 'eere/COMPLETE_EERE_CALCULATIONS';
+      type: 'eere/COMPLETE_EERE_PROFILE_CALCULATIONS';
       payload: CombinedProfile;
     };
 
@@ -184,8 +184,8 @@ type EereState = {
   )[];
   inputs: EEREInputs;
   selectOptions: { [field in SelectOptionsFieldName]: SelectOption[] };
-  calculationStatus: 'idle' | 'pending' | 'success';
-  calculationInputs: EEREInputs;
+  profileCalculationStatus: 'idle' | 'pending' | 'success';
+  profileCalculationInputs: EEREInputs;
   regionalProfiles: Partial<{ [key in RegionId]: RegionalProfile }>;
   combinedProfile: CombinedProfile;
 };
@@ -232,8 +232,8 @@ const initialState: EereState = {
     evModelYearOptions,
     iceReplacementVehicleOptions,
   },
-  calculationStatus: 'idle',
-  calculationInputs: initialEEREInputs,
+  profileCalculationStatus: 'idle',
+  profileCalculationInputs: initialEEREInputs,
   regionalProfiles: {},
   combinedProfile: {
     hourlyEere: [],
@@ -258,8 +258,8 @@ export default function reducer(
         errors: [],
         inputs: initialEEREInputs,
         // NOTE: selectOptions should not be reset
-        calculationStatus: 'idle',
-        calculationInputs: initialEEREInputs,
+        profileCalculationStatus: 'idle',
+        profileCalculationInputs: initialEEREInputs,
         regionalProfiles: {},
         combinedProfile: {
           hourlyEere: [],
@@ -468,12 +468,12 @@ export default function reducer(
       };
     }
 
-    case 'eere/START_EERE_CALCULATIONS': {
-      const { calculationInputs } = action.payload;
+    case 'eere/START_EERE_PROFILE_CALCULATIONS': {
+      const { profileCalculationInputs } = action.payload;
       return {
         ...state,
-        calculationStatus: 'pending',
-        calculationInputs,
+        profileCalculationStatus: 'pending',
+        profileCalculationInputs,
         regionalProfiles: {},
       };
     }
@@ -506,11 +506,11 @@ export default function reducer(
       };
     }
 
-    case 'eere/COMPLETE_EERE_CALCULATIONS': {
+    case 'eere/COMPLETE_EERE_PROFILE_CALCULATIONS': {
       const combinedProfile = action.payload;
       return {
         ...state,
-        calculationStatus: 'success',
+        profileCalculationStatus: 'success',
         combinedProfile,
       };
     }
@@ -815,8 +815,8 @@ export function calculateEereProfile(): AppThunk {
     }
 
     dispatch({
-      type: 'eere/START_EERE_CALCULATIONS',
-      payload: { calculationInputs: inputs },
+      type: 'eere/START_EERE_PROFILE_CALCULATIONS',
+      payload: { profileCalculationInputs: inputs },
     });
 
     // selected regional profiles are stored individually to pass to the
@@ -1038,7 +1038,7 @@ export function calculateEereProfile(): AppThunk {
       : emptyRegionalLoadHour;
 
     dispatch({
-      type: 'eere/COMPLETE_EERE_CALCULATIONS',
+      type: 'eere/COMPLETE_EERE_PROFILE_CALCULATIONS',
       payload: {
         hourlyEere: combinedHourlyEeres,
         softValid,

--- a/client/src/app/redux/reducers/eere.ts
+++ b/client/src/app/redux/reducers/eere.ts
@@ -106,7 +106,15 @@ type EereAction =
       payload: { text: string };
     }
   | {
+      type: 'eere/UPDATE_EERE_BATTERY_EVS_CALCULATIONS_INPUT';
+      payload: { text: string };
+    }
+  | {
       type: 'eere/UPDATE_EERE_HYBRID_EVS';
+      payload: { text: string };
+    }
+  | {
+      type: 'eere/UPDATE_EERE_HYBRID_EVS_CALCULATIONS_INPUT';
       payload: { text: string };
     }
   | {
@@ -114,7 +122,15 @@ type EereAction =
       payload: { text: string };
     }
   | {
+      type: 'eere/UPDATE_EERE_TRANSIT_BUSES_CALCULATIONS_INPUT';
+      payload: { text: string };
+    }
+  | {
       type: 'eere/UPDATE_EERE_SCHOOL_BUSES';
+      payload: { text: string };
+    }
+  | {
+      type: 'eere/UPDATE_EERE_SCHOOL_BUSES_CALCULATIONS_INPUT';
       payload: { text: string };
     }
   | {
@@ -184,6 +200,7 @@ type EereState = {
   )[];
   inputs: EEREInputs;
   selectOptions: { [field in SelectOptionsFieldName]: SelectOption[] };
+  evCalculationsInputs: { [field in ElectricVehiclesFieldName]: string };
   profileCalculationStatus: 'idle' | 'pending' | 'success';
   profileCalculationInputs: EEREInputs;
   regionalProfiles: Partial<{ [key in RegionId]: RegionalProfile }>;
@@ -232,6 +249,12 @@ const initialState: EereState = {
     evModelYearOptions,
     iceReplacementVehicleOptions,
   },
+  evCalculationsInputs: {
+    batteryEVs: '',
+    hybridEVs: '',
+    transitBuses: '',
+    schoolBuses: '',
+  },
   profileCalculationStatus: 'idle',
   profileCalculationInputs: initialEEREInputs,
   regionalProfiles: {},
@@ -258,6 +281,12 @@ export default function reducer(
         errors: [],
         inputs: initialEEREInputs,
         // NOTE: selectOptions should not be reset
+        evCalculationsInputs: {
+          batteryEVs: '',
+          hybridEVs: '',
+          transitBuses: '',
+          schoolBuses: '',
+        },
         profileCalculationStatus: 'idle',
         profileCalculationInputs: initialEEREInputs,
         regionalProfiles: {},
@@ -402,12 +431,34 @@ export default function reducer(
       };
     }
 
+    case 'eere/UPDATE_EERE_BATTERY_EVS_CALCULATIONS_INPUT': {
+      const { text } = action.payload;
+      return {
+        ...state,
+        evCalculationsInputs: {
+          ...state.evCalculationsInputs,
+          batteryEVs: text,
+        },
+      };
+    }
+
     case 'eere/UPDATE_EERE_HYBRID_EVS': {
       const { text } = action.payload;
       return {
         ...state,
         inputs: {
           ...state.inputs,
+          hybridEVs: text,
+        },
+      };
+    }
+
+    case 'eere/UPDATE_EERE_HYBRID_EVS_CALCULATIONS_INPUT': {
+      const { text } = action.payload;
+      return {
+        ...state,
+        evCalculationsInputs: {
+          ...state.evCalculationsInputs,
           hybridEVs: text,
         },
       };
@@ -424,12 +475,34 @@ export default function reducer(
       };
     }
 
+    case 'eere/UPDATE_EERE_TRANSIT_BUSES_CALCULATIONS_INPUT': {
+      const { text } = action.payload;
+      return {
+        ...state,
+        evCalculationsInputs: {
+          ...state.evCalculationsInputs,
+          transitBuses: text,
+        },
+      };
+    }
+
     case 'eere/UPDATE_EERE_SCHOOL_BUSES': {
       const { text } = action.payload;
       return {
         ...state,
         inputs: {
           ...state.inputs,
+          schoolBuses: text,
+        },
+      };
+    }
+
+    case 'eere/UPDATE_EERE_SCHOOL_BUSES_CALCULATIONS_INPUT': {
+      const { text } = action.payload;
+      return {
+        ...state,
+        evCalculationsInputs: {
+          ...state.evCalculationsInputs,
           schoolBuses: text,
         },
       };
@@ -698,7 +771,26 @@ export function updateEereBatteryEVs(input: string): AppThunk {
     });
 
     dispatch(validateInput('batteryEVs', input));
-    dispatch(setVehiclesDisplaced());
+  };
+}
+
+/**
+ * Called every time the batteryEVs inputs loses focus (e.g. onBlur)
+ */
+export function runEereBatteryEVsCalculations(input: string): AppThunk {
+  return (dispatch, getState) => {
+    const { eere } = getState();
+    const { batteryEVs } = eere.evCalculationsInputs;
+
+    /** only run calculations if the input has changed since the last onBlur */
+    if (input !== batteryEVs) {
+      dispatch(setVehiclesDisplaced());
+    }
+
+    dispatch({
+      type: 'eere/UPDATE_EERE_BATTERY_EVS_CALCULATIONS_INPUT',
+      payload: { text: input },
+    });
   };
 }
 
@@ -710,7 +802,26 @@ export function updateEereHybridEVs(input: string): AppThunk {
     });
 
     dispatch(validateInput('hybridEVs', input));
-    dispatch(setVehiclesDisplaced());
+  };
+}
+
+/**
+ * Called every time the hybridEVs inputs loses focus (e.g. onBlur)
+ */
+export function runEereHybridEVsCalculations(input: string): AppThunk {
+  return (dispatch, getState) => {
+    const { eere } = getState();
+    const { hybridEVs } = eere.evCalculationsInputs;
+
+    /** only run calculations if the input has changed since the last onBlur */
+    if (input !== hybridEVs) {
+      dispatch(setVehiclesDisplaced());
+    }
+
+    dispatch({
+      type: 'eere/UPDATE_EERE_HYBRID_EVS_CALCULATIONS_INPUT',
+      payload: { text: input },
+    });
   };
 }
 
@@ -722,7 +833,26 @@ export function updateEereTransitBuses(input: string): AppThunk {
     });
 
     dispatch(validateInput('transitBuses', input));
-    dispatch(setVehiclesDisplaced());
+  };
+}
+
+/**
+ * Called every time the transitBuses inputs loses focus (e.g. onBlur)
+ */
+export function runEereTransitBusesCalculations(input: string): AppThunk {
+  return (dispatch, getState) => {
+    const { eere } = getState();
+    const { transitBuses } = eere.evCalculationsInputs;
+
+    /** only run calculations if the input has changed since the last onBlur */
+    if (input !== transitBuses) {
+      dispatch(setVehiclesDisplaced());
+    }
+
+    dispatch({
+      type: 'eere/UPDATE_EERE_TRANSIT_BUSES_CALCULATIONS_INPUT',
+      payload: { text: input },
+    });
   };
 }
 
@@ -734,7 +864,26 @@ export function updateEereSchoolBuses(input: string): AppThunk {
     });
 
     dispatch(validateInput('schoolBuses', input));
-    dispatch(setVehiclesDisplaced());
+  };
+}
+
+/**
+ * Called every time the schoolBuses inputs loses focus (e.g. onBlur)
+ */
+export function runEereSchoolBusesCalculations(input: string): AppThunk {
+  return (dispatch, getState) => {
+    const { eere } = getState();
+    const { schoolBuses } = eere.evCalculationsInputs;
+
+    /** only run calculations if the input has changed since the last onBlur */
+    if (input !== schoolBuses) {
+      dispatch(setVehiclesDisplaced());
+    }
+
+    dispatch({
+      type: 'eere/UPDATE_EERE_SCHOOL_BUSES_CALCULATIONS_INPUT',
+      payload: { text: input },
+    });
   };
 }
 

--- a/client/src/app/redux/reducers/panel.ts
+++ b/client/src/app/redux/reducers/panel.ts
@@ -14,8 +14,8 @@ type Action =
     }
   | { type: 'geography/REQUEST_SELECTED_REGIONS_DATA' }
   | { type: 'geography/RECEIVE_SELECTED_REGIONS_DATA' }
-  | { type: 'eere/START_EERE_CALCULATIONS' }
-  | { type: 'eere/COMPLETE_EERE_CALCULATIONS' }
+  | { type: 'eere/START_EERE_PROFILE_CALCULATIONS' }
+  | { type: 'eere/COMPLETE_EERE_PROFILE_CALCULATIONS' }
   | { type: 'results/FETCH_EMISSIONS_CHANGES_REQUEST' }
   | { type: 'results/FETCH_EMISSIONS_CHANGES_SUCCESS' };
 
@@ -78,7 +78,7 @@ export default function reducer(
     }
 
     case 'geography/REQUEST_SELECTED_REGIONS_DATA':
-    case 'eere/START_EERE_CALCULATIONS':
+    case 'eere/START_EERE_PROFILE_CALCULATIONS':
     case 'results/FETCH_EMISSIONS_CHANGES_REQUEST': {
       return {
         ...state,
@@ -87,7 +87,7 @@ export default function reducer(
     }
 
     case 'geography/RECEIVE_SELECTED_REGIONS_DATA':
-    case 'eere/COMPLETE_EERE_CALCULATIONS':
+    case 'eere/COMPLETE_EERE_PROFILE_CALCULATIONS':
     case 'results/FETCH_EMISSIONS_CHANGES_SUCCESS': {
       return {
         ...state,

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -699,11 +699,12 @@ export function setDailyAndMonthlyStats(): AppThunk {
 }
 
 /**
- * Called every time the `eere` reducer's `updateEereBatteryEVs()`,
- * `updateEereHybridEVs()`, `updateEereTransitBuses()`, or
- * `updateEereSchoolBuses()` function are called.
+ * Called every time the `eere` reducer's `runEereBatteryEVsCalculations()`,
+ * `runEereHybridEVsCalculations()`, `runEereTransitBusesCalculations()`, or
+ * `runEereSchoolBusesCalculations()` function are called.
  *
- * (e.g. whenever an EV input number changes)
+ * _(e.g. onBlur / whenever an EV input loses focus, but only if the input's
+ * value has changed since the last time it was used in this calculation)_
  */
 export function setVehiclesDisplaced(): AppThunk {
   return (dispatch, getState) => {


### PR DESCRIPTION
Improve performance of EERE panel (really EV calculations happening behind the scenes) by deferring running some transportation calculations until after the user tabs out of an EV input.

NOTE: the app still feels fast as the "EV Sales and Stock Comparison" table still updates immediately as the user's EV input values change – its just the values shown in the "EE/RE and EV Comparison" table will now update after each EV input looses focus (or after the user hits the enter key). That delay in running the calculations makes the app much more responsive with little to no perceived delay to the end user.