### PR TITLE
Feature/add find my region feature

### DIFF
--- a/client/src/app/calculations/geography.ts
+++ b/client/src/app/calculations/geography.ts
@@ -17,9 +17,6 @@ export type RegionalScalingFactors = ReturnType<
 export type SelectedGeographyRegions = ReturnType<
   typeof getSelectedGeographyRegions
 >;
-export type SelectedGeographyCounties = ReturnType<
-  typeof getSelectedGeographyCounties
->;
 
 /**
  * Organizes counties into AVERT regions.
@@ -111,55 +108,6 @@ export function getSelectedGeographyRegions(options: {
     }
     return object;
   }, {} as Partial<{ [regionId in RegionId]: RegionState }>);
-
-  return result;
-}
-
-/**
- * Returns the counties for the selected geography.
- */
-export function getSelectedGeographyCounties(options: {
-  selectedGeographyRegions: SelectedGeographyRegions;
-}) {
-  const { selectedGeographyRegions } = options;
-
-  const result = {} as Partial<{
-    [regionId in RegionId]: Partial<{
-      [stateId in StateId]: string[];
-    }>;
-  }>;
-
-  const selectedRegions = Object.entries(selectedGeographyRegions).reduce(
-    (object, [key, value]) => {
-      const regionId = key as keyof typeof selectedGeographyRegions;
-      object[regionId] = value.name;
-      return object;
-    },
-    {} as { [regionId in RegionId]: string },
-  );
-
-  countyFips.forEach((data) => {
-    const regionName = data['AVERT Region'] as RegionName;
-    const stateId = data['Postal State Code'] as StateId;
-    const county = data['County Name Long'];
-
-    if (Object.values(selectedRegions).includes(regionName)) {
-      const regionId = Object.entries(selectedRegions).find(([_, name]) => {
-        return name === regionName;
-      })?.[0] as RegionId | undefined;
-
-      if (regionId) {
-        result[regionId] ??= {} as Partial<{ [stateId in StateId]: string[] }>;
-
-        const regionResult = result[regionId];
-
-        if (regionResult) {
-          regionResult[stateId] ??= [];
-          regionResult[stateId]?.push(county);
-        }
-      }
-    }
-  });
 
   return result;
 }

--- a/client/src/app/calculations/geography.ts
+++ b/client/src/app/calculations/geography.ts
@@ -28,10 +28,18 @@ export function organizeCountiesByGeography(options: {
 }) {
   const { regions } = options;
 
-  const result = {} as {
-    [regionId in RegionId]: Partial<{
+  const result = {
+    regions: {},
+    states: {},
+  } as {
+    regions: {
+      [regionId in RegionId]: Partial<{
+        [stateId in StateId]: string[];
+      }>;
+    };
+    states: {
       [stateId in StateId]: string[];
-    }>;
+    };
   };
 
   countyFips.forEach((data) => {
@@ -44,18 +52,26 @@ export function organizeCountiesByGeography(options: {
     })?.[0] as RegionId | undefined;
 
     if (regionId) {
-      result[regionId] ??= {} as Partial<{ [stateId in StateId]: string[] }>;
+      result.regions[regionId] ??= {} as Partial<{
+        [stateId in StateId]: string[];
+      }>;
 
-      const regionResult = result[regionId];
+      const regionResult = result.regions[regionId];
 
       if (regionResult) {
         regionResult[stateId] ??= [];
         regionResult[stateId]?.push(county);
+
+        result.states[stateId] ??= [];
+        result.states[stateId]?.push(county);
       }
     }
   });
 
-  return sortObjectByKeys(result);
+  result.regions = sortObjectByKeys(result.regions);
+  result.states = sortObjectByKeys(result.states);
+
+  return result;
 }
 
 /**

--- a/client/src/app/calculations/geography.ts
+++ b/client/src/app/calculations/geography.ts
@@ -10,7 +10,9 @@ import type { RegionId, RegionName, StateId } from 'app/config';
  */
 import countyFips from 'app/data/county-fips.json';
 
-export type CountiesByRegion = ReturnType<typeof organizeCountiesByRegion>;
+export type CountiesByGeography = ReturnType<
+  typeof organizeCountiesByGeography
+>;
 export type RegionalScalingFactors = ReturnType<
   typeof calculateRegionalScalingFactors
 >;
@@ -19,9 +21,9 @@ export type SelectedGeographyRegions = ReturnType<
 >;
 
 /**
- * Organizes counties into AVERT regions.
+ * Organizes counties by state and by AVERT regions.
  */
-export function organizeCountiesByRegion(options: {
+export function organizeCountiesByGeography(options: {
   regions: { [regionId in RegionId]: RegionState };
 }) {
   const { regions } = options;

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -1,7 +1,7 @@
 import { RegionalLoadData } from 'app/redux/reducers/geography';
 import type { GeographicFocus } from 'app/redux/reducers/geography';
 import type {
-  CountiesByRegion,
+  CountiesByGeography,
   RegionalScalingFactors,
   SelectedGeographyRegions,
 } from 'app/calculations/geography';
@@ -1692,7 +1692,7 @@ export function calculateVehicleEmissionChangesByGeography(options: {
   geographicFocus: GeographicFocus;
   selectedRegionId: RegionId | '';
   selectedStateId: StateId | '';
-  countiesByRegion: CountiesByRegion | {};
+  countiesByGeography: CountiesByGeography | {};
   selectedGeographyRegionIds: RegionId[];
   vmtPerVehicleTypeByGeography: VMTPerVehicleTypeByGeography | {};
   totalYearlyEmissionChanges: TotalYearlyEmissionChanges;
@@ -1702,7 +1702,7 @@ export function calculateVehicleEmissionChangesByGeography(options: {
     geographicFocus,
     selectedRegionId,
     selectedStateId,
-    countiesByRegion,
+    countiesByGeography,
     selectedGeographyRegionIds,
     vmtPerVehicleTypeByGeography,
     totalYearlyEmissionChanges,
@@ -1745,18 +1745,18 @@ export function calculateVehicleEmissionChangesByGeography(options: {
       ? (vmtPerVehicleTypeByGeography as VMTPerVehicleTypeByGeography)
       : null;
 
-  const countiesByRegionData =
-    Object.keys(countiesByRegion).length !== 0
-      ? (countiesByRegion as CountiesByRegion)
+  const countiesByRegion =
+    Object.keys(countiesByGeography).length !== 0
+      ? (countiesByGeography as CountiesByGeography)
       : null;
 
-  if (!countiesByRegionData || !vmtData || evDeploymentLocation === '') {
+  if (!countiesByRegion || !vmtData || evDeploymentLocation === '') {
     return result;
   }
 
-  const selectedRegionsCounties = Object.entries(countiesByRegionData).reduce(
+  const selectedRegionsCounties = Object.entries(countiesByRegion).reduce(
     (object, [key, value]) => {
-      const regionId = key as keyof typeof countiesByRegionData;
+      const regionId = key as keyof typeof countiesByRegion;
 
       if (selectedGeographyRegionIds.includes(regionId)) {
         object[regionId] = value;

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -1745,14 +1745,16 @@ export function calculateVehicleEmissionChangesByGeography(options: {
       ? (vmtPerVehicleTypeByGeography as VMTPerVehicleTypeByGeography)
       : null;
 
-  const countiesByRegion =
+  const countiesByGeographyData =
     Object.keys(countiesByGeography).length !== 0
       ? (countiesByGeography as CountiesByGeography)
       : null;
 
-  if (!countiesByRegion || !vmtData || evDeploymentLocation === '') {
+  if (!countiesByGeographyData || !vmtData || evDeploymentLocation === '') {
     return result;
   }
+
+  const countiesByRegion = countiesByGeographyData.regions;
 
   const selectedRegionsCounties = Object.entries(countiesByRegion).reduce(
     (object, [key, value]) => {

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -1,9 +1,9 @@
 import { RegionalLoadData } from 'app/redux/reducers/geography';
 import type { GeographicFocus } from 'app/redux/reducers/geography';
 import type {
+  CountiesByRegion,
   RegionalScalingFactors,
   SelectedGeographyRegions,
-  SelectedGeographyCounties,
 } from 'app/calculations/geography';
 import { sortObjectByKeys } from 'app/calculations/utilities';
 import type { RegionId, RegionName, StateId } from 'app/config';
@@ -1692,18 +1692,20 @@ export function calculateVehicleEmissionChangesByGeography(options: {
   geographicFocus: GeographicFocus;
   selectedRegionId: RegionId | '';
   selectedStateId: StateId | '';
+  countiesByRegion: CountiesByRegion | {};
+  selectedGeographyRegionIds: RegionId[];
   vmtPerVehicleTypeByGeography: VMTPerVehicleTypeByGeography | {};
   totalYearlyEmissionChanges: TotalYearlyEmissionChanges;
-  selectedGeographyCounties: SelectedGeographyCounties;
   evDeploymentLocation: string;
 }) {
   const {
     geographicFocus,
     selectedRegionId,
     selectedStateId,
+    countiesByRegion,
+    selectedGeographyRegionIds,
     vmtPerVehicleTypeByGeography,
     totalYearlyEmissionChanges,
-    selectedGeographyCounties,
     evDeploymentLocation,
   } = options;
 
@@ -1743,7 +1745,31 @@ export function calculateVehicleEmissionChangesByGeography(options: {
       ? (vmtPerVehicleTypeByGeography as VMTPerVehicleTypeByGeography)
       : null;
 
-  if (!vmtData || evDeploymentLocation === '') return result;
+  const countiesByRegionData =
+    Object.keys(countiesByRegion).length !== 0
+      ? (countiesByRegion as CountiesByRegion)
+      : null;
+
+  if (!countiesByRegionData || !vmtData || evDeploymentLocation === '') {
+    return result;
+  }
+
+  const selectedRegionsCounties = Object.entries(countiesByRegionData).reduce(
+    (object, [key, value]) => {
+      const regionId = key as keyof typeof countiesByRegionData;
+
+      if (selectedGeographyRegionIds.includes(regionId)) {
+        object[regionId] = value;
+      }
+
+      return object;
+    },
+    {} as Partial<{
+      [regionId in RegionId]: Partial<{
+        [stateId in StateId]: string[];
+      }>;
+    }>,
+  );
 
   const deploymentLocationIsRegion = evDeploymentLocation.startsWith('region-');
   const deploymentLocationIsState = evDeploymentLocation.startsWith('state-');
@@ -1768,7 +1794,7 @@ export function calculateVehicleEmissionChangesByGeography(options: {
 
       Object.entries(stateCountiesVMT).forEach(([county, countyVMT]) => {
         /** determine which region the county falls within */
-        const regionId = Object.entries(selectedGeographyCounties).find(
+        const regionId = Object.entries(selectedRegionsCounties).find(
           ([_, regionData]) => {
             return Object.entries(regionData).some(([key, value]) => {
               return (key as StateId) === stateId && value.includes(county);
@@ -1778,7 +1804,7 @@ export function calculateVehicleEmissionChangesByGeography(options: {
 
         if (
           regionId &&
-          selectedGeographyCounties[regionId]?.[stateId]?.includes(county)
+          selectedRegionsCounties[regionId]?.[stateId]?.includes(county)
         ) {
           // initialize each region, state, and county's values for each pollutant
           result.regions[regionId] ??= { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 }; // prettier-ignore

--- a/client/src/app/components/Panels.tsx
+++ b/client/src/app/components/Panels.tsx
@@ -26,7 +26,10 @@ import { DataDownload } from 'app/components/DataDownload';
 import { modalLinkStyles } from 'app/components/Tooltip';
 import { useTypedSelector } from 'app/redux/index';
 import { toggleModalOverlay, resetActiveModal } from 'app/redux/reducers/panel';
-import { selectGeography } from 'app/redux/reducers/geography';
+import {
+  setCountiesByRegion,
+  selectGeography,
+} from 'app/redux/reducers/geography';
 import {
   setVMTData,
   setHourlyEVChargingPercentages,
@@ -248,6 +251,7 @@ export function Panels() {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    dispatch(setCountiesByRegion());
     dispatch(setVMTData());
     dispatch(setHourlyEVChargingPercentages());
   }, [dispatch]);

--- a/client/src/app/components/Panels.tsx
+++ b/client/src/app/components/Panels.tsx
@@ -214,6 +214,36 @@ function StateTable(props: { location: string }) {
   );
 }
 
+function ExcelAppText() {
+  return (
+    <p className="text-base-dark font-sans-2xs tablet:font-sans-xs desktop:font-sans-sm">
+      The online version of AVERT completes analyses using 2021 emissions and
+      generation data. The Excel version of AVERT (
+      <a
+        className="usa-link"
+        href="https://www.epa.gov/avert/download-avert"
+        target="_parent"
+        rel="noreferrer"
+      >
+        available for download here
+      </a>
+      ) allows analyses for years 2017–2021 or for a future year scenario.
+    </p>
+  );
+}
+
+function StateGeographyText() {
+  return (
+    <p className="text-base-dark font-sans-2xs tablet:font-sans-xs desktop:font-sans-sm">
+      When modeling EE/RE in a state, AVERT distributes the user-input EE/RE
+      across all the AVERT regions straddled by the state. The energy impacts of
+      EE/RE programs are assigned to each AVERT region based on the proportional
+      generation provided to the state by EGUs in each AVERT region. For more
+      information, see Appendix G of the User Manual.
+    </p>
+  );
+}
+
 export function Panels() {
   const dispatch = useDispatch();
 
@@ -346,36 +376,33 @@ export function Panels() {
             <TabPanel>
               <div className="grid-container padding-0 maxw-full">
                 <div className="grid-row" style={{ margin: '0 -0.5rem' }}>
-                  <div className="padding-1 margin-x-auto maxw-desktop">
-                    <p className="margin-bottom-0 tablet:margin-top-2 font-sans-xs tablet:font-sans-sm desktop:font-sans-md">
-                      AVERT splits the contiguous 48 states into 14 independent
-                      electricity regions. AVERT regions are organized by one or
-                      more balancing authorities. Select a region for analysis
-                      by either using the dropdown menu or clicking the map.
-                      Selecting a region loads the power plants operating within
-                      each region and region-specific wind and solar capacity
-                      data.
-                    </p>
-
-                    <RegionsList />
-                    <RegionsMap />
-
-                    <div className="margin-x-auto maxw-tablet-lg">
-                      <p className="text-base-dark font-sans-2xs tablet:font-sans-xs desktop:font-sans-sm">
-                        The online version of AVERT completes analyses using
-                        2021 emissions and generation data. The Excel version of
-                        AVERT (
-                        <a
-                          className="usa-link"
-                          href="https://www.epa.gov/avert/download-avert"
-                          target="_parent"
-                          rel="noreferrer"
-                        >
-                          available for download here
-                        </a>
-                        ) allows analyses for years 2017–2021 or for a future
-                        year scenario.
+                  <div className="desktop:grid-col-6 desktop:order-last">
+                    <div className="padding-x-2">
+                      <p className="margin-bottom-0 tablet:margin-top-2 font-sans-xs tablet:font-sans-sm desktop:font-sans-md">
+                        AVERT splits the contiguous 48 states into 14
+                        independent electricity regions. AVERT regions are
+                        organized by one or more balancing authorities. Select a
+                        region for analysis by either using the dropdown menu or
+                        clicking the map. Selecting a region loads the power
+                        plants operating within each region and region-specific
+                        wind and solar capacity data.
                       </p>
+
+                      <RegionsList />
+
+                      <div className="display-none desktop:display-block desktop:margin-top-4">
+                        <ExcelAppText />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="desktop:grid-col-6">
+                    <div className="padding-x-2">
+                      <RegionsMap />
+
+                      <div className="desktop:display-none">
+                        <ExcelAppText />
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -383,44 +410,35 @@ export function Panels() {
             </TabPanel>
 
             <TabPanel>
-              <div className="grid-row" style={{ margin: '0 -0.5rem' }}>
-                <div className="padding-1 margin-x-auto maxw-desktop">
-                  <p className="margin-bottom-0 tablet:margin-top-2 font-sans-xs tablet:font-sans-sm desktop:font-sans-md">
-                    Select a state for analysis by either using the dropdown
-                    menu or clicking the map. Selecting a state means AVERT will
-                    load power plants and wind and solar capacity factors for
-                    all regions that the state is part of.
-                  </p>
+              <div className="grid-container padding-0 maxw-full">
+                <div className="grid-row" style={{ margin: '0 -0.5rem' }}>
+                  <div className="desktop:grid-col-6 desktop:order-last">
+                    <div className="padding-x-2">
+                      <p className="margin-bottom-0 tablet:margin-top-2 font-sans-xs tablet:font-sans-sm desktop:font-sans-md">
+                        Select a state for analysis by either using the dropdown
+                        menu or clicking the map. Selecting a state means AVERT
+                        will load power plants and wind and solar capacity
+                        factors for all regions that the state is part of.
+                      </p>
 
-                  <StatesList />
-                  <StatesMap />
+                      <StatesList />
 
-                  <div className="margin-x-auto maxw-tablet-lg">
-                    <p className="text-base-dark font-sans-2xs tablet:font-sans-xs desktop:font-sans-sm">
-                      When modeling EE/RE in a state, AVERT distributes the
-                      user-input EE/RE across all the AVERT regions straddled by
-                      the state. The energy impacts of EE/RE programs are
-                      assigned to each AVERT region based on the proportional
-                      generation provided to the state by EGUs in each AVERT
-                      region. For more information, see Appendix G of the User
-                      Manual.
-                    </p>
+                      <div className="display-none desktop:display-block desktop:margin-top-4">
+                        <StateGeographyText />
+                        <ExcelAppText />
+                      </div>
+                    </div>
+                  </div>
 
-                    <p className="text-base-dark font-sans-2xs tablet:font-sans-xs desktop:font-sans-sm">
-                      The online version of AVERT completes analyses using 2021
-                      emissions and generation data. The Excel version of AVERT
-                      (
-                      <a
-                        className="usa-link"
-                        href="https://www.epa.gov/avert/download-avert"
-                        target="_parent"
-                        rel="noreferrer"
-                      >
-                        available for download here
-                      </a>
-                      ) allows analyses for years 2017–2021 or for a future year
-                      scenario.
-                    </p>
+                  <div className="desktop:grid-col-6">
+                    <div className="padding-x-2">
+                      <StatesMap />
+
+                      <div className="desktop:display-none">
+                        <StateGeographyText />
+                        <ExcelAppText />
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/client/src/app/components/Panels.tsx
+++ b/client/src/app/components/Panels.tsx
@@ -382,15 +382,15 @@ export function Panels() {
                         AVERT splits the contiguous 48 states into 14
                         independent electricity regions. AVERT regions are
                         organized by one or more balancing authorities. Select a
-                        region for analysis by either using the dropdown menu or
-                        clicking the map. Selecting a region loads the power
+                        region for analysis by either using the dropdown menus
+                        or clicking the map. Selecting a region loads the power
                         plants operating within each region and region-specific
                         wind and solar capacity data.
                       </p>
 
                       <RegionsList />
 
-                      <div className="display-none desktop:display-block desktop:margin-top-4">
+                      <div className="display-none desktop:display-block desktop:margin-top-3">
                         <ExcelAppText />
                       </div>
                     </div>
@@ -423,7 +423,7 @@ export function Panels() {
 
                       <StatesList />
 
-                      <div className="display-none desktop:display-block desktop:margin-top-4">
+                      <div className="display-none desktop:display-block desktop:margin-top-3">
                         <StateGeographyText />
                         <ExcelAppText />
                       </div>

--- a/client/src/app/components/RegionsList.tsx
+++ b/client/src/app/components/RegionsList.tsx
@@ -23,6 +23,7 @@ function RegionsListContent() {
     [],
   );
 
+  // update county options, based on selected state
   useEffect(() => {
     const countiesByGeographyData =
       Object.keys(countiesByGeography).length !== 0
@@ -38,6 +39,32 @@ function RegionsListContent() {
       }
     }
   }, [countiesByGeography, selectRegionStateId]);
+
+  // update selected region, based on selected county
+  useEffect(() => {
+    const countiesByGeographyData =
+      Object.keys(countiesByGeography).length !== 0
+        ? (countiesByGeography as CountiesByGeography)
+        : null;
+
+    if (countiesByGeographyData) {
+      const stateId = selectRegionStateId as StateId;
+      const county = selectRegionCounty;
+
+      /** determine which region the county falls within */
+      const regionId = Object.entries(countiesByGeographyData.regions).find(
+        ([_, regionData]) => {
+          return Object.entries(regionData).some(([key, value]) => {
+            return (key as StateId) === stateId && value.includes(county);
+          });
+        },
+      )?.[0] as RegionId | undefined;
+
+      if (regionId) {
+        dispatch(selectRegion(regionId));
+      }
+    }
+  }, [countiesByGeography, selectRegionStateId, selectRegionCounty, dispatch]);
 
   return (
     <div className="text-base-darker">
@@ -92,7 +119,9 @@ function RegionsListContent() {
             {selectRegionCounties.map((county) => {
               return (
                 <Fragment key={county}>
-                  <option value={county}>{county}</option>
+                  <option value={county}>
+                    {county.replace(/city/, '(City)')}
+                  </option>
                 </Fragment>
               );
             })}
@@ -112,6 +141,8 @@ function RegionsListContent() {
             value={selectedRegionId || ''}
             onChange={(ev) => {
               dispatch(selectRegion(ev.target.value as RegionId));
+              setSelectRegionStateId('');
+              setSelectRegionCounty('');
             }}
             data-avert-region-select
           >

--- a/client/src/app/components/RegionsList.tsx
+++ b/client/src/app/components/RegionsList.tsx
@@ -87,6 +87,7 @@ function RegionsListContent() {
             aria-label="Select State"
             value={regionSelectStateId || ''}
             onChange={(ev) => {
+              dispatch(selectRegion('' as RegionId));
               dispatch(setRegionSelectStateId(ev.target.value as StateId));
               dispatch(setRegionSelectCounty(''));
             }}

--- a/client/src/app/components/RegionsList.tsx
+++ b/client/src/app/components/RegionsList.tsx
@@ -10,32 +10,82 @@ function RegionsListContent() {
 
   const selectedRegionId = useSelectedRegion()?.id;
 
+  // TODO: replace with data stored in redux state
+  const selectedRegionStateId = '';
+  const selectedRegionCounty = '';
+
   return (
-    <select
-      className="usa-select margin-top-3 margin-bottom-0 margin-x-auto width-full tablet:margin-top-4"
-      aria-label="Select Region"
-      value={selectedRegionId || ''}
-      onChange={(ev) => dispatch(selectRegion(ev.target.value as RegionId))}
-      data-avert-region-select
-    >
-      <option value={''} disabled>
-        Select Region
-      </option>
-      <option value={regions.CA.id}>{regions.CA.name}</option>
-      <option value={regions.NCSC.id}>{regions.NCSC.name}</option>
-      <option value={regions.CENT.id}>{regions.CENT.name}</option>
-      <option value={regions.FL.id}>{regions.FL.name}</option>
-      <option value={regions.MIDA.id}>{regions.MIDA.name}</option>
-      <option value={regions.MIDW.id}>{regions.MIDW.name}</option>
-      <option value={regions.NE.id}>{regions.NE.name}</option>
-      <option value={regions.NY.id}>{regions.NY.name}</option>
-      <option value={regions.NW.id}>{regions.NW.name}</option>
-      <option value={regions.RM.id}>{regions.RM.name}</option>
-      <option value={regions.SE.id}>{regions.SE.name}</option>
-      <option value={regions.SW.id}>{regions.SW.name}</option>
-      <option value={regions.TN.id}>{regions.TN.name}</option>
-      <option value={regions.TE.id}>{regions.TE.name}</option>
-    </select>
+    <>
+      <p className="margin-top-2 margin-bottom-05">
+        <strong>Select a state and county:</strong>
+      </p>
+
+      <div className="display-flex">
+        <div className="flex-1 margin-right-1">
+          <select
+            className="usa-select margin-0 maxw-full"
+            aria-label="Select State"
+            value={selectedRegionStateId || ''}
+            // onChange={(ev) => dispatch(selectRegionState(ev.target.value as StateId))}
+            data-avert-region-state-select
+          >
+            <option value={''} disabled>
+              Select State
+            </option>
+          </select>
+        </div>
+
+        <div className="flex-1 margin-left-1">
+          <select
+            className="usa-select margin-0 maxw-full"
+            aria-label="Select County"
+            value={selectedRegionCounty || ''}
+            // onChange={(ev) => dispatch(selectRegionCounty(ev.target.value))}
+            data-avert-region-county-select
+          >
+            <option value={''} disabled>
+              Select County
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <p className="margin-top-2 margin-bottom-05">
+        <strong>Or select a region directly:</strong>
+      </p>
+
+      <div className="display-flex">
+        <div className="flex-1">
+          <select
+            className="usa-select margin-0 maxw-full"
+            aria-label="Select Region"
+            value={selectedRegionId || ''}
+            onChange={(ev) =>
+              dispatch(selectRegion(ev.target.value as RegionId))
+            }
+            data-avert-region-select
+          >
+            <option value={''} disabled>
+              Select Region
+            </option>
+            <option value={regions.CA.id}>{regions.CA.name}</option>
+            <option value={regions.NCSC.id}>{regions.NCSC.name}</option>
+            <option value={regions.CENT.id}>{regions.CENT.name}</option>
+            <option value={regions.FL.id}>{regions.FL.name}</option>
+            <option value={regions.MIDA.id}>{regions.MIDA.name}</option>
+            <option value={regions.MIDW.id}>{regions.MIDW.name}</option>
+            <option value={regions.NE.id}>{regions.NE.name}</option>
+            <option value={regions.NY.id}>{regions.NY.name}</option>
+            <option value={regions.NW.id}>{regions.NW.name}</option>
+            <option value={regions.RM.id}>{regions.RM.name}</option>
+            <option value={regions.SE.id}>{regions.SE.name}</option>
+            <option value={regions.SW.id}>{regions.SW.name}</option>
+            <option value={regions.TN.id}>{regions.TN.name}</option>
+            <option value={regions.TE.id}>{regions.TE.name}</option>
+          </select>
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/client/src/app/components/RegionsList.tsx
+++ b/client/src/app/components/RegionsList.tsx
@@ -31,13 +31,19 @@ function RegionsListContent() {
 
   // update county select options, based on selected state
   useEffect(() => {
+    const stateId = regionSelectStateId;
+
     const countiesByGeographyData =
       Object.keys(countiesByGeography).length !== 0
         ? (countiesByGeography as CountiesByGeography)
         : null;
 
-    if (countiesByGeographyData && regionSelectStateId !== '') {
-      const stateId = regionSelectStateId;
+    if (stateId === '') {
+      setCountyNames([]);
+      return;
+    }
+
+    if (countiesByGeographyData) {
       const selectedStateCounties = countiesByGeographyData.states[stateId];
 
       if (selectedStateCounties) {
@@ -48,15 +54,19 @@ function RegionsListContent() {
 
   // update selected region, based on selected county
   useEffect(() => {
+    const stateId = regionSelectStateId;
+    const county = regionSelectCounty;
+
     const countiesByGeographyData =
       Object.keys(countiesByGeography).length !== 0
         ? (countiesByGeography as CountiesByGeography)
         : null;
 
-    if (countiesByGeographyData && regionSelectStateId !== '') {
-      const stateId = regionSelectStateId;
-      const county = regionSelectCounty;
+    if (stateId === '') {
+      return;
+    }
 
+    if (countiesByGeographyData) {
       /** determine which region the county falls within */
       const regionId = Object.entries(countiesByGeographyData.regions).find(
         ([_, regionData]) => {

--- a/client/src/app/components/RegionsList.tsx
+++ b/client/src/app/components/RegionsList.tsx
@@ -12,7 +12,7 @@ function RegionsListContent() {
 
   return (
     <select
-      className="usa-select margin-top-3 margin-bottom-0 margin-x-auto width-full tablet:margin-top-5"
+      className="usa-select margin-top-3 margin-bottom-0 margin-x-auto width-full tablet:margin-top-4"
       aria-label="Select Region"
       value={selectedRegionId || ''}
       onChange={(ev) => dispatch(selectRegion(ev.target.value as RegionId))}

--- a/client/src/app/components/RegionsMap.tsx
+++ b/client/src/app/components/RegionsMap.tsx
@@ -67,9 +67,14 @@ import { Washington } from 'app/components/States/Washington';
 import { Wisconsin } from 'app/components/States/Wisconsin';
 import { WestVirginia } from 'app/components/States/WestVirginia';
 import { Wyoming } from 'app/components/States/Wyoming';
-import { selectRegion } from 'app/redux/reducers/geography';
+import {
+  selectRegion,
+  setRegionSelectStateId,
+  setRegionSelectCounty,
+} from 'app/redux/reducers/geography';
 import { useSelectedRegion } from 'app/hooks';
-import { RegionId, regions } from 'app/config';
+import type { RegionId } from 'app/config';
+import { regions } from 'app/config';
 
 const containerStyles = css`
   /* padding-top: intrinsic aspect ratio so SVG displays property in IE */
@@ -157,7 +162,11 @@ function Region(props: {
     <g
       css={regionStyles}
       fill={fill}
-      onClick={(ev) => dispatch(selectRegion(id))}
+      onClick={(_ev) => {
+        dispatch(selectRegion(id));
+        dispatch(setRegionSelectStateId(''));
+        dispatch(setRegionSelectCounty(''));
+      }}
       data-active={selectedRegionId === id}
     >
       {children}

--- a/client/src/app/components/StatesList.tsx
+++ b/client/src/app/components/StatesList.tsx
@@ -12,25 +12,33 @@ function StatesListContent() {
   const selectedStateId = useSelectedState()?.id;
 
   return (
-    <select
-      className="usa-select margin-top-3 margin-bottom-0 margin-x-auto width-full tablet:margin-top-4"
-      aria-label="Select State"
-      value={selectedStateId || ''}
-      onChange={(ev) => dispatch(selectState(ev.target.value as StateId))}
-      data-avert-state-select
-    >
-      <option value={''} disabled>
-        Select State
-      </option>
+    <div className="margin-top-3">
+      <div className="display-flex">
+        <div className="flex-1">
+          <select
+            className="usa-select margin-0 maxw-full"
+            aria-label="Select State"
+            value={selectedStateId || ''}
+            onChange={(ev) => dispatch(selectState(ev.target.value as StateId))}
+            data-avert-state-select
+          >
+            <option value={''} disabled>
+              Select State
+            </option>
 
-      {Object.keys(states).map((stateId) => {
-        return (
-          <Fragment key={stateId}>
-            <option value={stateId}>{states[stateId as StateId].name}</option>
-          </Fragment>
-        );
-      })}
-    </select>
+            {Object.keys(states).map((stateId) => {
+              return (
+                <Fragment key={stateId}>
+                  <option value={stateId}>
+                    {states[stateId as StateId].name}
+                  </option>
+                </Fragment>
+              );
+            })}
+          </select>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/client/src/app/components/StatesList.tsx
+++ b/client/src/app/components/StatesList.tsx
@@ -13,7 +13,7 @@ function StatesListContent() {
 
   return (
     <select
-      className="usa-select margin-top-3 margin-bottom-0 margin-x-auto width-full tablet:margin-top-5"
+      className="usa-select margin-top-3 margin-bottom-0 margin-x-auto width-full tablet:margin-top-4"
       aria-label="Select State"
       value={selectedStateId || ''}
       onChange={(ev) => dispatch(selectState(ev.target.value as StateId))}

--- a/client/src/app/components/StatesList.tsx
+++ b/client/src/app/components/StatesList.tsx
@@ -4,7 +4,8 @@ import { useDispatch } from 'react-redux';
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { selectState } from 'app/redux/reducers/geography';
 import { useSelectedState } from 'app/hooks';
-import { StateId, states } from 'app/config';
+import type { StateId } from 'app/config';
+import { states } from 'app/config';
 
 function StatesListContent() {
   const dispatch = useDispatch();
@@ -12,7 +13,7 @@ function StatesListContent() {
   const selectedStateId = useSelectedState()?.id;
 
   return (
-    <div className="margin-top-3">
+    <div className="margin-top-3 text-base-darker">
       <div className="display-flex">
         <div className="flex-1">
           <select

--- a/client/src/app/redux/reducers/geography.ts
+++ b/client/src/app/redux/reducers/geography.ts
@@ -112,6 +112,14 @@ type GeographyAction =
       payload: { stateId: StateId };
     }
   | {
+      type: 'geography/SET_REGION_SELECT_STATE_ID';
+      payload: { stateId: StateId | '' };
+    }
+  | {
+      type: 'geography/SET_REGION_SELECT_COUNTY';
+      payload: { county: string };
+    }
+  | {
       type: 'geography/SET_REGIONAL_SCALING_FACTORS';
       payload: {
         regionalScalingFactors: RegionalScalingFactors;
@@ -153,6 +161,10 @@ type GeographyState = {
   regions: { [key in RegionId]: RegionState };
   states: { [key in StateId]: StateState };
   countiesByGeography: CountiesByGeography | {};
+  regionSelect: {
+    stateId: StateId | '';
+    county: string;
+  };
   regionalScalingFactors: RegionalScalingFactors;
   regionalLineLoss: number;
 };
@@ -222,6 +234,10 @@ const initialState: GeographyState = {
   regions: updatedRegions,
   states: updatedStates,
   countiesByGeography: {},
+  regionSelect: {
+    stateId: '',
+    county: '',
+  },
   regionalScalingFactors: {},
   regionalLineLoss: 0,
 };
@@ -270,6 +286,30 @@ export default function reducer(
         updatedState.states[stateId].selected = stateIsSelected;
       }
       return updatedState;
+    }
+
+    case 'geography/SET_REGION_SELECT_STATE_ID': {
+      const { stateId } = action.payload;
+
+      return {
+        ...state,
+        regionSelect: {
+          ...state.regionSelect,
+          stateId,
+        },
+      };
+    }
+
+    case 'geography/SET_REGION_SELECT_COUNTY': {
+      const { county } = action.payload;
+
+      return {
+        ...state,
+        regionSelect: {
+          ...state.regionSelect,
+          county,
+        },
+      };
     }
 
     case 'geography/SET_REGIONAL_SCALING_FACTORS': {
@@ -367,7 +407,7 @@ export function selectGeography(focus: GeographicFocus): AppThunk {
 
 /**
  * Called every time a region is clicked on the map or selected from the regions
- * dropdown list on the "Select Geography" page
+ * dropdown list in the "Select Region" tab on the "Select Geography" page.
  */
 export function selectRegion(regionId: RegionId): AppThunk {
   return (dispatch) => {
@@ -385,7 +425,7 @@ export function selectRegion(regionId: RegionId): AppThunk {
 
 /**
  * Called every time a state is clicked on the map or selected from the states
- * dropdown list on the "Select Geography" page
+ * dropdown list in the "Select State" tab of the "Select Geography" page.
  */
 export function selectState(stateId: string): AppThunk {
   return (dispatch) => {
@@ -398,6 +438,30 @@ export function selectState(stateId: string): AppThunk {
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
     dispatch(setEVEfficiency());
+  };
+}
+
+/**
+ * Called every time a region is clicked on the map or a state is selected from
+ * the states dropdown list in the "Select Region" tab of the "Select Geography"
+ * page.
+ */
+export function setRegionSelectStateId(stateId: StateId | ''): GeographyAction {
+  return {
+    type: 'geography/SET_REGION_SELECT_STATE_ID',
+    payload: { stateId },
+  };
+}
+
+/**
+ * Called every time a region is clicked on the map or a county is selected from
+ * the counties dropdown list in the "Select Region" tab of the "Select
+ * Geography" page.
+ */
+export function setRegionSelectCounty(county: string): GeographyAction {
+  return {
+    type: 'geography/SET_REGION_SELECT_COUNTY',
+    payload: { county },
   };
 }
 

--- a/client/src/app/redux/reducers/geography.ts
+++ b/client/src/app/redux/reducers/geography.ts
@@ -375,8 +375,7 @@ export function selectGeography(focus: GeographicFocus): AppThunk {
       payload: { focus },
     });
 
-    dispatch(setRegionalScalingFactors());
-    dispatch(setRegionalLineLoss());
+    dispatch(setRegionalScalingFactorsAndLineLoss());
     dispatch(setSelectedGeographyCounties());
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
@@ -395,8 +394,7 @@ export function selectRegion(regionId: RegionId): AppThunk {
       payload: { regionId },
     });
 
-    dispatch(setRegionalScalingFactors());
-    dispatch(setRegionalLineLoss());
+    dispatch(setRegionalScalingFactorsAndLineLoss());
     dispatch(setSelectedGeographyCounties());
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
@@ -415,8 +413,7 @@ export function selectState(stateId: string): AppThunk {
       payload: { stateId },
     });
 
-    dispatch(setRegionalScalingFactors());
-    dispatch(setRegionalLineLoss());
+    dispatch(setRegionalScalingFactorsAndLineLoss());
     dispatch(setSelectedGeographyCounties());
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
@@ -430,7 +427,7 @@ export function selectState(stateId: string): AppThunk {
  *
  * _(e.g. anytime the selected geography changes)_
  */
-function setRegionalScalingFactors(): AppThunk {
+function setRegionalScalingFactorsAndLineLoss(): AppThunk {
   return (dispatch, getState) => {
     const { geography } = getState();
     const { focus, regions, states } = geography;
@@ -440,24 +437,6 @@ function setRegionalScalingFactors(): AppThunk {
       selectedRegion: Object.values(regions).find((r) => r.selected),
       selectedState: Object.values(states).find((s) => s.selected),
     });
-
-    dispatch({
-      type: 'geography/SET_REGIONAL_SCALING_FACTORS',
-      payload: { regionalScalingFactors },
-    });
-  };
-}
-
-/**
- * Called every time this `geography` reducer's `selectGeography()`,
- * `selectRegion()`, or `selectState()` functions are called.
- *
- * _(e.g. anytime the selected geography changes)_
- */
-function setRegionalLineLoss(): AppThunk {
-  return (dispatch, getState) => {
-    const { geography } = getState();
-    const { regions, regionalScalingFactors } = geography;
 
     const selectedGeographyRegionIds = Object.keys(
       regionalScalingFactors,
@@ -485,6 +464,11 @@ function setRegionalLineLoss(): AppThunk {
       },
       0,
     );
+
+    dispatch({
+      type: 'geography/SET_REGIONAL_SCALING_FACTORS',
+      payload: { regionalScalingFactors },
+    });
 
     dispatch({
       type: 'geography/SET_REGIONAL_LINE_LOSS',

--- a/client/src/app/redux/reducers/geography.ts
+++ b/client/src/app/redux/reducers/geography.ts
@@ -3,13 +3,11 @@ import { setEVDeploymentLocationOptions } from 'app/redux/reducers/eere';
 import type {
   CountiesByRegion,
   RegionalScalingFactors,
-  SelectedGeographyCounties,
 } from 'app/calculations/geography';
 import {
   organizeCountiesByRegion,
   calculateRegionalScalingFactors,
   getSelectedGeographyRegions,
-  getSelectedGeographyCounties,
 } from 'app/calculations/geography';
 import {
   setSelectedGeographyVMTData,
@@ -123,10 +121,6 @@ type GeographyAction =
       type: 'geography/SET_REGIONAL_LINE_LOSS';
       payload: { regionalLineLoss: number };
     }
-  | {
-      type: 'geography/SET_SELECTED_GEOGRAPHY_COUNTIES';
-      payload: { selectedGeographyCounties: SelectedGeographyCounties };
-    }
   | { type: 'geography/REQUEST_SELECTED_REGIONS_DATA' }
   | { type: 'geography/RECEIVE_SELECTED_REGIONS_DATA' }
   | {
@@ -161,7 +155,6 @@ type GeographyState = {
   countiesByRegion: CountiesByRegion | {};
   regionalScalingFactors: RegionalScalingFactors;
   regionalLineLoss: number;
-  selectedGeographyCounties: SelectedGeographyCounties;
 };
 
 const initialRegionEereDefaults = {
@@ -231,7 +224,6 @@ const initialState: GeographyState = {
   countiesByRegion: {},
   regionalScalingFactors: {},
   regionalLineLoss: 0,
-  selectedGeographyCounties: {},
 };
 
 export default function reducer(
@@ -295,15 +287,6 @@ export default function reducer(
       return {
         ...state,
         regionalLineLoss,
-      };
-    }
-
-    case 'geography/SET_SELECTED_GEOGRAPHY_COUNTIES': {
-      const { selectedGeographyCounties } = action.payload;
-
-      return {
-        ...state,
-        selectedGeographyCounties,
       };
     }
 
@@ -376,7 +359,6 @@ export function selectGeography(focus: GeographicFocus): AppThunk {
     });
 
     dispatch(setRegionalScalingFactorsAndLineLoss());
-    dispatch(setSelectedGeographyCounties());
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
     dispatch(setEVEfficiency());
@@ -395,7 +377,6 @@ export function selectRegion(regionId: RegionId): AppThunk {
     });
 
     dispatch(setRegionalScalingFactorsAndLineLoss());
-    dispatch(setSelectedGeographyCounties());
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
     dispatch(setEVEfficiency());
@@ -414,7 +395,6 @@ export function selectState(stateId: string): AppThunk {
     });
 
     dispatch(setRegionalScalingFactorsAndLineLoss());
-    dispatch(setSelectedGeographyCounties());
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
     dispatch(setEVEfficiency());
@@ -473,37 +453,6 @@ function setRegionalScalingFactorsAndLineLoss(): AppThunk {
     dispatch({
       type: 'geography/SET_REGIONAL_LINE_LOSS',
       payload: { regionalLineLoss },
-    });
-  };
-}
-
-/**
- * Called every time this `geography` reducer's `selectGeography()`,
- * `selectRegion()`, or `selectState()` functions are called.
- *
- * _(e.g. anytime the selected geography changes)_
- */
-function setSelectedGeographyCounties(): AppThunk {
-  return (dispatch, getState) => {
-    const { geography } = getState();
-    const { regions, regionalScalingFactors } = geography;
-
-    const selectedGeographyRegionIds = Object.keys(
-      regionalScalingFactors,
-    ) as RegionId[];
-
-    const selectedGeographyRegions = getSelectedGeographyRegions({
-      regions,
-      selectedGeographyRegionIds,
-    });
-
-    const selectedGeographyCounties = getSelectedGeographyCounties({
-      selectedGeographyRegions,
-    });
-
-    dispatch({
-      type: 'geography/SET_SELECTED_GEOGRAPHY_COUNTIES',
-      payload: { selectedGeographyCounties },
     });
   };
 }

--- a/client/src/app/redux/reducers/geography.ts
+++ b/client/src/app/redux/reducers/geography.ts
@@ -1,11 +1,11 @@
 import { AppThunk } from 'app/redux/index';
 import { setEVDeploymentLocationOptions } from 'app/redux/reducers/eere';
 import type {
-  CountiesByRegion,
+  CountiesByGeography,
   RegionalScalingFactors,
 } from 'app/calculations/geography';
 import {
-  organizeCountiesByRegion,
+  organizeCountiesByGeography,
   calculateRegionalScalingFactors,
   getSelectedGeographyRegions,
 } from 'app/calculations/geography';
@@ -96,8 +96,8 @@ type EEREJSON = {
 
 type GeographyAction =
   | {
-      type: 'geography/SET_COUNTIES_BY_REGION';
-      payload: { countiesByRegion: CountiesByRegion };
+      type: 'geography/SET_COUNTIES_BY_GEOGRAPHY';
+      payload: { countiesByGeography: CountiesByGeography };
     }
   | {
       type: 'geography/SELECT_GEOGRAPHY';
@@ -152,7 +152,7 @@ type GeographyState = {
   focus: GeographicFocus;
   regions: { [key in RegionId]: RegionState };
   states: { [key in StateId]: StateState };
-  countiesByRegion: CountiesByRegion | {};
+  countiesByGeography: CountiesByGeography | {};
   regionalScalingFactors: RegionalScalingFactors;
   regionalLineLoss: number;
 };
@@ -221,7 +221,7 @@ const initialState: GeographyState = {
   focus: 'regions',
   regions: updatedRegions,
   states: updatedStates,
-  countiesByRegion: {},
+  countiesByGeography: {},
   regionalScalingFactors: {},
   regionalLineLoss: 0,
 };
@@ -231,12 +231,12 @@ export default function reducer(
   action: GeographyAction,
 ): GeographyState {
   switch (action.type) {
-    case 'geography/SET_COUNTIES_BY_REGION': {
-      const { countiesByRegion } = action.payload;
+    case 'geography/SET_COUNTIES_BY_GEOGRAPHY': {
+      const { countiesByGeography } = action.payload;
 
       return {
         ...state,
-        countiesByRegion,
+        countiesByGeography,
       };
     }
 
@@ -338,11 +338,11 @@ export function setCountiesByRegion(): AppThunk {
   return (dispatch, getState) => {
     const { geography } = getState();
     const { regions } = geography;
-    const countiesByRegion = organizeCountiesByRegion({ regions });
+    const countiesByGeography = organizeCountiesByGeography({ regions });
 
     dispatch({
-      type: 'geography/SET_COUNTIES_BY_REGION',
-      payload: { countiesByRegion },
+      type: 'geography/SET_COUNTIES_BY_GEOGRAPHY',
+      payload: { countiesByGeography },
     });
   };
 }

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -856,7 +856,7 @@ export function setMonthlyEmissionRates(): AppThunk {
 export function setEmissionChanges(): AppThunk {
   return (dispatch, getState) => {
     const { geography, transportation, eere } = getState();
-    const { countiesByRegion, regionalScalingFactors } = geography;
+    const { countiesByGeography, regionalScalingFactors } = geography;
     const {
       vmtPerVehicleTypeByGeography,
       monthlyVMTPerVehicleType,
@@ -897,7 +897,7 @@ export function setEmissionChanges(): AppThunk {
         geographicFocus,
         selectedRegionId,
         selectedStateId,
-        countiesByRegion,
+        countiesByGeography,
         selectedGeographyRegionIds,
         vmtPerVehicleTypeByGeography,
         totalYearlyEmissionChanges,

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -856,7 +856,7 @@ export function setMonthlyEmissionRates(): AppThunk {
 export function setEmissionChanges(): AppThunk {
   return (dispatch, getState) => {
     const { geography, transportation, eere } = getState();
-    const { selectedGeographyCounties } = geography;
+    const { countiesByRegion, regionalScalingFactors } = geography;
     const {
       vmtPerVehicleTypeByGeography,
       monthlyVMTPerVehicleType,
@@ -888,14 +888,19 @@ export function setEmissionChanges(): AppThunk {
     const selectedStateId =
       Object.values(geography.states).find((s) => s.selected)?.id || '';
 
+    const selectedGeographyRegionIds = Object.keys(
+      regionalScalingFactors,
+    ) as RegionId[];
+
     const vehicleEmissionChangesByGeography =
       calculateVehicleEmissionChangesByGeography({
         geographicFocus,
         selectedRegionId,
         selectedStateId,
+        countiesByRegion,
+        selectedGeographyRegionIds,
         vmtPerVehicleTypeByGeography,
         totalYearlyEmissionChanges,
-        selectedGeographyCounties,
         evDeploymentLocation,
       });
 


### PR DESCRIPTION
Update the "Select Geography" panel to include new select options for the user to select an AVERT region, based on state and county selection. Users can continue to select a region directly from the regions dropdown menu, or by clicking the map as before. As part of the new select options, the UI has also been updated to better take advantage of the wider layout by using a two column layout with the map to the left and the explanatory text and select options to the right (for both the "Select Region" and "Select State" tabs).