### PR TITLE
Feature/update transportation data calculations

### DIFF
--- a/client/src/app/calculations/eere.ts
+++ b/client/src/app/calculations/eere.ts
@@ -7,7 +7,7 @@ import type {
 import type {
   DailyStats,
   HourlyEVChargingPercentages,
-  MonthlyDailyEVEnergyUsage,
+  SelectedRegionsMonthlyDailyEVEnergyUsage,
 } from 'app/calculations/transportation';
 import type { RegionId } from 'app/config';
 
@@ -66,23 +66,32 @@ export function calculateHourlyRenewableEnergyProfile(options: {
  * Excel: Data in column Y of the "CalculateEERE" sheet (Y5:Y8788).
  */
 export function calculateHourlyEVLoad(options: {
+  regionId: RegionId;
   regionalLoad: RegionalLoadData[];
   dailyStats: DailyStats;
   hourlyEVChargingPercentages: HourlyEVChargingPercentages;
-  monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage;
+  selectedRegionsMonthlyDailyEVEnergyUsage: SelectedRegionsMonthlyDailyEVEnergyUsage | {}; // prettier-ignore
 }) {
   const {
+    regionId,
     regionalLoad,
     dailyStats,
     hourlyEVChargingPercentages,
-    monthlyDailyEVEnergyUsage,
+    selectedRegionsMonthlyDailyEVEnergyUsage,
   } = options;
+
+  const selectedRegionsEnergyData =
+    Object.keys(selectedRegionsMonthlyDailyEVEnergyUsage).length !== 0
+      ? (selectedRegionsMonthlyDailyEVEnergyUsage as SelectedRegionsMonthlyDailyEVEnergyUsage)
+      : null;
+
+  const monthlyDailyEVEnergyUsage = selectedRegionsEnergyData?.[regionId];
 
   if (
     regionalLoad.length === 0 ||
     Object.keys(dailyStats).length === 0 ||
     Object.keys(hourlyEVChargingPercentages).length === 0 ||
-    Object.keys(monthlyDailyEVEnergyUsage).length === 0
+    !monthlyDailyEVEnergyUsage
   ) {
     return [];
   }

--- a/client/src/app/calculations/emissions.ts
+++ b/client/src/app/calculations/emissions.ts
@@ -493,10 +493,12 @@ export function createCombinedSectorsEmissionsData(options: {
 
           Object.entries(regionMonthValue.total).forEach(([key, value]) => {
             const pollutant = key as keyof typeof regionMonthValue.total;
+            // conditionally convert CO2 tons into pounds
+            const result = pollutant === 'CO2' ? value / 2_000 : value;
 
-            object[regionId][pollutant][month] = -1 * value;
+            object[regionId][pollutant][month] = -1 * result;
             object.regionTotals[pollutant][month] ??= 0;
-            object.regionTotals[pollutant][month] += -1 * value;
+            object.regionTotals[pollutant][month] += -1 * result;
           });
         },
       );

--- a/client/src/app/calculations/emissions.ts
+++ b/client/src/app/calculations/emissions.ts
@@ -555,9 +555,10 @@ export function createCombinedSectorsEmissionsData(options: {
   /** add county level transportation sector emissions data */
   Object.entries(vehicleEmissionChanges.counties).forEach(([key, value]) => {
     const stateId = key as keyof typeof vehicleEmissionChanges.counties;
-    result.counties[stateId] ??= {};
 
     Object.keys(value).forEach((countyName) => {
+      result.counties[stateId] ??= {};
+
       /** initialize county data if it doesn't already exist */
       result.counties[stateId][countyName] ??= {
         generation: { power: null, vehicle: null },

--- a/client/src/app/calculations/emissions.ts
+++ b/client/src/app/calculations/emissions.ts
@@ -493,7 +493,7 @@ export function createCombinedSectorsEmissionsData(options: {
 
           Object.entries(regionMonthValue.total).forEach(([key, value]) => {
             const pollutant = key as keyof typeof regionMonthValue.total;
-            // conditionally convert CO2 tons into pounds
+            // conditionally convert CO2 pounds into tons
             const result = pollutant === 'CO2' ? value / 2_000 : value;
 
             object[regionId][pollutant][month] = -1 * result;

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -1254,7 +1254,12 @@ export function calculateSelectedRegionsMonthlyEVEnergyUsageGW(options: {
       ? (selectedRegionsMonthlyVMTPerVehicleType as SelectedRegionsMonthlyVMTPerVehicleType)
       : null;
 
-  if (!selectedRegionsVMTData) {
+  const selectedRegionsEfficiencyData =
+    Object.keys(selectedRegionsEVEfficiencyPerVehicleType).length !== 0
+      ? (selectedRegionsEVEfficiencyPerVehicleType as SelectedRegionsEVEfficiencyPerVehicleType)
+      : null;
+
+  if (!selectedRegionsVMTData || !selectedRegionsEfficiencyData) {
     return result;
   }
 
@@ -1267,52 +1272,52 @@ export function calculateSelectedRegionsMonthlyEVEnergyUsageGW(options: {
       ([regionKey, regionValue]) => {
         const regionId = regionKey as keyof typeof selectedRegionsVMTData;
         const monthlyVmt = regionValue[month];
+        const regionEVEfficiency = selectedRegionsEfficiencyData[regionId];
 
-        result[regionId] ??= {};
-
-        if (monthlyVmt) {
+        if (monthlyVmt && regionEVEfficiency) {
+          result[regionId] ??= {};
           result[regionId][month] = {
             batteryEVCars:
               vehiclesDisplaced.batteryEVCars *
               monthlyVmt.cars *
-              selectedRegionsEVEfficiencyPerVehicleType.batteryEVCars *
+              regionEVEfficiency.batteryEVCars *
               KWtoGW,
             hybridEVCars:
               vehiclesDisplaced.hybridEVCars *
               monthlyVmt.cars *
-              selectedRegionsEVEfficiencyPerVehicleType.hybridEVCars *
+              regionEVEfficiency.hybridEVCars *
               KWtoGW *
               percentageHybridEVMilesDrivenOnElectricity,
             batteryEVTrucks:
               vehiclesDisplaced.batteryEVTrucks *
               monthlyVmt.trucks *
-              selectedRegionsEVEfficiencyPerVehicleType.batteryEVTrucks *
+              regionEVEfficiency.batteryEVTrucks *
               KWtoGW,
             hybridEVTrucks:
               vehiclesDisplaced.hybridEVTrucks *
               monthlyVmt.trucks *
-              selectedRegionsEVEfficiencyPerVehicleType.hybridEVTrucks *
+              regionEVEfficiency.hybridEVTrucks *
               KWtoGW *
               percentageHybridEVMilesDrivenOnElectricity,
             transitBusesDiesel:
               vehiclesDisplaced.transitBusesDiesel *
               monthlyVmt.transitBusesDiesel *
-              selectedRegionsEVEfficiencyPerVehicleType.transitBuses *
+              regionEVEfficiency.transitBuses *
               KWtoGW,
             transitBusesCNG:
               vehiclesDisplaced.transitBusesCNG *
               monthlyVmt.transitBusesCNG *
-              selectedRegionsEVEfficiencyPerVehicleType.transitBuses *
+              regionEVEfficiency.transitBuses *
               KWtoGW,
             transitBusesGasoline:
               vehiclesDisplaced.transitBusesGasoline *
               monthlyVmt.transitBusesGasoline *
-              selectedRegionsEVEfficiencyPerVehicleType.transitBuses *
+              regionEVEfficiency.transitBuses *
               KWtoGW,
             schoolBuses:
               vehiclesDisplaced.schoolBuses *
               monthlyVmt.schoolBuses *
-              selectedRegionsEVEfficiencyPerVehicleType.schoolBuses *
+              regionEVEfficiency.schoolBuses *
               KWtoGW,
           };
         }

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -860,13 +860,29 @@ export function calculateSelectedRegionsAverageVMTPerYear(options: {
 }) {
   const { selectedRegionsVMTPercentagesPerVehicleType } = options;
 
-  const result = Object.entries(
-    selectedRegionsVMTPercentagesPerVehicleType,
-  ).reduce(
-    (object, [key, data]) => {
-      const { vmtPerLDVPercent, vmtPerBusPercent } = data;
+  const selectedRegionsVMTData =
+    Object.keys(selectedRegionsVMTPercentagesPerVehicleType).length !== 0
+      ? (selectedRegionsVMTPercentagesPerVehicleType as SelectedRegionsVMTPercentagesPerVehicleType)
+      : null;
 
-      object[key as RegionId] = {
+  if (!selectedRegionsVMTData) {
+    return {} as {
+      [regionId in RegionId]: {
+        cars: number;
+        trucks: number;
+        transitBuses: number;
+        schoolBuses: number;
+      };
+    };
+  }
+
+  const result = Object.entries(selectedRegionsVMTData).reduce(
+    (object, [regionKey, regionValue]) => {
+      const regionId = regionKey as keyof typeof selectedRegionsVMTData;
+
+      const { vmtPerLDVPercent, vmtPerBusPercent } = regionValue;
+
+      object[regionId] = {
         cars: nationalAverageVMTPerYear.cars * vmtPerLDVPercent,
         trucks: nationalAverageVMTPerYear.trucks * vmtPerLDVPercent,
         transitBuses: nationalAverageVMTPerYear.transitBuses * vmtPerBusPercent,

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -2132,7 +2132,7 @@ export function calculateVehicleEmissionChangesByGeography(options: {
           ) {
             Object.values(selectedRegionsChangesData).forEach((changes) => {
               pollutants.forEach((pollutant) => {
-                // conditionally convert CO2 tons into pounds
+                // conditionally convert CO2 pounds into tons
                 const unitFactor = pollutant === 'CO2' ? 2_000 : 1;
 
                 const cars =

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -2106,8 +2106,6 @@ export function calculateVehicleEmissionChangesByGeography(options: {
       locationVMT &&
       (regionSelected || (stateSelected && selectedStateId === stateId))
     ) {
-      result.counties[stateId] ??= {};
-
       Object.entries(stateCountiesVMT).forEach(([county, countyVMT]) => {
         /** determine which region the county falls within */
         const regionId = Object.entries(selectedRegionsCounties).find(
@@ -2125,6 +2123,7 @@ export function calculateVehicleEmissionChangesByGeography(options: {
           // initialize each region, state, and county's values for each pollutant
           result.regions[regionId] ??= { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 }; // prettier-ignore
           result.states[stateId] ??= { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 }; // prettier-ignore
+          result.counties[stateId] ??= {};
           result.counties[stateId][county] ??= { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 }; // prettier-ignore
 
           if (

--- a/client/src/app/calculations/transportation.ts
+++ b/client/src/app/calculations/transportation.ts
@@ -701,27 +701,35 @@ export function calculateSelectedRegionsStatesVMTPercentages(options: {
     allBuses: number;
   };
 
-  const result = Object.entries(vmtAllocationTotalsAndPercentages).reduce(
-    (object, [key, data]) => {
-      if (key === 'regionTotals') return object;
+  const vmtAllocationData =
+    Object.keys(vmtAllocationTotalsAndPercentages).length !== 0
+      ? (vmtAllocationTotalsAndPercentages as VMTAllocationTotalsAndPercentages)
+      : null;
 
-      const stateId = key as StateId;
-      const stateRegionIds = Object.keys(data); // NOTE: also includes 'allRegions' key
+  if (!vmtAllocationData) {
+    return {} as {
+      [regionId in RegionId]: {
+        [stateId in StateId]: StateVMTPercentages;
+      };
+    };
+  }
 
-      const vmtStatesData =
-        Object.keys(vmtAllocationTotalsAndPercentages).length !== 0
-          ? (vmtAllocationTotalsAndPercentages as VMTAllocationTotalsAndPercentages)
-          : null;
+  const result = Object.entries(vmtAllocationData).reduce(
+    (object, [key, value]) => {
+      const stateId = key as keyof typeof vmtAllocationData;
 
-      const vmtStateData = vmtStatesData?.[stateId];
+      if (stateId === 'regionTotals') return object;
+
+      const stateRegionIds = Object.keys(value); // NOTE: also includes 'allRegions' key
+      const stateVMTData = vmtAllocationData?.[stateId];
 
       if (
-        vmtStateData &&
+        stateVMTData &&
         geographicFocus === 'regions' &&
         selectedRegionId !== '' &&
         stateRegionIds.includes(selectedRegionId)
       ) {
-        const selectedRegionData = vmtStateData[selectedRegionId];
+        const selectedRegionData = stateVMTData[selectedRegionId];
 
         if (selectedRegionData) {
           object[selectedRegionId] ??= {} as {
@@ -740,12 +748,12 @@ export function calculateSelectedRegionsStatesVMTPercentages(options: {
       }
 
       if (
-        vmtStateData &&
+        stateVMTData &&
         geographicFocus === 'states' &&
         selectedStateId !== '' &&
         stateId === selectedStateId
       ) {
-        Object.entries(vmtStateData).forEach(([stateKey, stateData]) => {
+        Object.entries(stateVMTData).forEach(([stateKey, stateData]) => {
           if (stateKey !== 'allRegions') {
             object[stateKey as RegionId] ??= {} as {
               [stateId in StateId]: StateVMTPercentages;

--- a/client/src/app/components/EVTables.tsx
+++ b/client/src/app/components/EVTables.tsx
@@ -1,5 +1,6 @@
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { useTypedSelector } from 'app/redux/index';
+import type { SelectedRegionsTotalYearlyEVEnergyUsage } from 'app/calculations/transportation';
 
 function calculatePercent(numerator: number, denominator: number) {
   return denominator !== 0
@@ -144,12 +145,22 @@ function EEREEVComparisonTableContent(props: { className?: string }) {
   const regionalLineLoss = useTypedSelector(
     ({ geography }) => geography.regionalLineLoss,
   );
-  const totalYearlyEVEnergyUsage = useTypedSelector(
-    ({ transportation }) => transportation.totalYearlyEVEnergyUsage,
+  const selectedRegionsTotalYearlyEVEnergyUsage = useTypedSelector(
+    ({ transportation }) =>
+      transportation.selectedRegionsTotalYearlyEVEnergyUsage,
   );
   const evDeploymentLocationHistoricalEERE = useTypedSelector(
     ({ transportation }) => transportation.evDeploymentLocationHistoricalEERE,
   );
+
+  const selectedRegionsEnergyData =
+    Object.keys(selectedRegionsTotalYearlyEVEnergyUsage).length !== 0
+      ? (selectedRegionsTotalYearlyEVEnergyUsage as SelectedRegionsTotalYearlyEVEnergyUsage)
+      : null;
+
+  const totalYearlyEVEnergyUsage = selectedRegionsEnergyData
+    ? Object.values(selectedRegionsEnergyData).reduce((a, b) => a + b, 0)
+    : 0;
 
   const historicalEERetailMw = evDeploymentLocationHistoricalEERE.eeRetail.mw;
   const historicalEERetailGWh = evDeploymentLocationHistoricalEERE.eeRetail.gwh;

--- a/client/src/app/components/MonthlyEmissionsCharts.tsx
+++ b/client/src/app/components/MonthlyEmissionsCharts.tsx
@@ -72,6 +72,25 @@ function setMonthlyPowerData(
 }
 
 /**
+ * Creates monthly transportation sector emissions data for display in the
+ * monthly charts.
+ */
+function setMonthlyVehicleData(data: EmissionsData[keyof EmissionsData]) {
+  const monthlyEmissionsChanges: number[] = [];
+
+  const vehicleData = data.vehicle;
+  if (!vehicleData) return [];
+
+  for (const key in vehicleData.monthly) {
+    const month = Number(key);
+    const data = vehicleData.monthly[month];
+    monthlyEmissionsChanges.push(data);
+  }
+
+  return monthlyEmissionsChanges;
+}
+
+/**
  * Sets chart series data based on the currently selected source(s) and unit.
  */
 function setChartSeriesData(options: {
@@ -108,9 +127,6 @@ function Chart(props: {
   const { pollutant, data, vehicleDataExists } = props;
 
   const geographicFocus = useTypedSelector(({ geography }) => geography.focus);
-  const totalMonthlyEmissionChanges = useTypedSelector(
-    ({ transportation }) => transportation.totalMonthlyEmissionChanges,
-  );
   const egusNeedingEmissionsReplacement = useTypedSelector(
     ({ results }) => results.egusNeedingEmissionsReplacement,
   );
@@ -139,30 +155,6 @@ function Chart(props: {
   const selectedRegion = useSelectedRegion();
   const selectedStateRegions = useSelectedStateRegions();
 
-  const vehicleEmissions = Object.values(totalMonthlyEmissionChanges).reduce(
-    (object, data) => {
-      ['CO2', 'NOX', 'SO2', 'PM25', 'VOCs', 'NH3'].forEach((item) => {
-        const pollutant = item as keyof typeof data.total;
-        const value = -1 * data.total[pollutant];
-
-        if (value) {
-          const result = pollutant === 'CO2' ? value / 2_000 : value;
-          object[pollutant].push(result);
-        }
-      });
-
-      return object;
-    },
-    { SO2: [], NOX: [], CO2: [], PM25: [], VOCs: [], NH3: [] } as {
-      SO2: number[];
-      NOX: number[];
-      CO2: number[];
-      PM25: number[];
-      VOCs: number[];
-      NH3: number[];
-    },
-  );
-
   // console.log({ data, vehicleEmissions }); // NOTE: for debugging purposes
 
   const so2Data = {
@@ -174,7 +166,7 @@ function Chart(props: {
     },
     vehicles: {
       name: 'Vehicles',
-      data: vehicleDataExists ? vehicleEmissions.SO2 : null,
+      data: vehicleDataExists ? setMonthlyVehicleData(data.so2) : null,
       color: 'rgba(5, 141, 199, 0.5)',
       unit: 'lb',
     },
@@ -189,7 +181,7 @@ function Chart(props: {
     },
     vehicles: {
       name: 'Vehicles',
-      data: vehicleDataExists ? vehicleEmissions.NOX : null,
+      data: vehicleDataExists ? setMonthlyVehicleData(data.nox) : null,
       color: 'rgba(237, 86, 27, 0.5)',
       unit: 'lb',
     },
@@ -204,7 +196,7 @@ function Chart(props: {
     },
     vehicles: {
       name: 'Vehicles',
-      data: vehicleDataExists ? vehicleEmissions.CO2 : null,
+      data: vehicleDataExists ? setMonthlyVehicleData(data.co2) : null,
       color: 'rgba(80, 180, 50, 0.5)',
       unit: 'tons',
     },
@@ -219,7 +211,7 @@ function Chart(props: {
     },
     vehicles: {
       name: 'Vehicles',
-      data: vehicleDataExists ? vehicleEmissions.PM25 : null,
+      data: vehicleDataExists ? setMonthlyVehicleData(data.pm25) : null,
       color: 'rgba(102, 86, 131, 0.5)',
       unit: 'lb',
     },
@@ -234,7 +226,7 @@ function Chart(props: {
     },
     vehicles: {
       name: 'Vehicles',
-      data: vehicleDataExists ? vehicleEmissions.VOCs : null,
+      data: vehicleDataExists ? setMonthlyVehicleData(data.vocs) : null,
       color: 'rgba(255, 193, 7, 0.5)',
       unit: 'lb',
     },
@@ -249,7 +241,7 @@ function Chart(props: {
     },
     vehicles: {
       name: 'Vehicles',
-      data: vehicleDataExists ? vehicleEmissions.NH3 : null,
+      data: vehicleDataExists ? setMonthlyVehicleData(data.nh3) : null,
       color: 'rgba(0, 150, 136, 0.5)',
       unit: 'lb',
     },

--- a/client/src/app/components/StateEmissionsTable.tsx
+++ b/client/src/app/components/StateEmissionsTable.tsx
@@ -43,7 +43,7 @@ function setAnnualStateEmissionsChanges(
             }
 
             if (stateVehicleData !== null) {
-              object.vehicle[pollutant] = stateVehicleData;
+              object.vehicle[pollutant] = stateVehicleData.annual;
             }
           }
 

--- a/client/src/app/components/VehiclesEmissionsTable.tsx
+++ b/client/src/app/components/VehiclesEmissionsTable.tsx
@@ -66,6 +66,7 @@ function setAnnualVehicleEmissionsChanges(options: {
       ['CO2', 'NOX', 'SO2', 'PM25', 'VOCs', 'NH3'].forEach((item) => {
         const pollutant = item as keyof typeof regionChanges.total;
         const value = -1 * regionChanges.total[pollutant];
+        // conditionally convert CO2 tons into pounds
         const result = pollutant === 'CO2' ? value / 2_000 : value;
 
         object[pollutant] += result;

--- a/client/src/app/components/VehiclesEmissionsTable.tsx
+++ b/client/src/app/components/VehiclesEmissionsTable.tsx
@@ -66,7 +66,7 @@ function setAnnualVehicleEmissionsChanges(options: {
       ['CO2', 'NOX', 'SO2', 'PM25', 'VOCs', 'NH3'].forEach((item) => {
         const pollutant = item as keyof typeof regionChanges.total;
         const value = -1 * regionChanges.total[pollutant];
-        // conditionally convert CO2 tons into pounds
+        // conditionally convert CO2 pounds into tons
         const result = pollutant === 'CO2' ? value / 2_000 : value;
 
         object[pollutant] += result;

--- a/client/src/app/components/VehiclesEmissionsTable.tsx
+++ b/client/src/app/components/VehiclesEmissionsTable.tsx
@@ -1,5 +1,6 @@
 import { ErrorBoundary } from 'app/components/ErrorBoundary';
 import { useTypedSelector } from 'app/redux/index';
+import type { SelectedRegionsTotalYearlyEmissionChanges } from 'app/calculations/transportation';
 import type { CombinedSectorsEmissionsData } from 'app/calculations/emissions';
 
 /**
@@ -13,11 +14,13 @@ function formatNumber(number: number) {
 }
 
 /**
- * Calculate the annual emissions changes for each pollutant.
+ * Calculate the annual power sector emissions changes for each pollutant.
  */
-function setAnnualEmissionsChanges(
-  combinedSectorsEmissionsData: CombinedSectorsEmissionsData,
-) {
+function setAnnualPowerEmissionsChanges(options: {
+  combinedSectorsEmissionsData: CombinedSectorsEmissionsData;
+}) {
+  const { combinedSectorsEmissionsData } = options;
+
   if (!combinedSectorsEmissionsData) {
     return { generation: 0, so2: 0, nox: 0, co2: 0, pm25: 0, vocs: 0, nh3: 0 };
   }
@@ -40,31 +43,58 @@ function setAnnualEmissionsChanges(
   return result;
 }
 
+/**
+ * Calculate the annual transportation sector emissions changes for each
+ * pollutant.
+ */
+function setAnnualVehicleEmissionsChanges(options: {
+  selectedRegionsTotalYearlyEmissionChanges: SelectedRegionsTotalYearlyEmissionChanges | {} // prettier-ignore
+}) {
+  const { selectedRegionsTotalYearlyEmissionChanges } = options;
+
+  const selectedRegionsChangesData =
+    Object.keys(selectedRegionsTotalYearlyEmissionChanges).length !== 0
+      ? (selectedRegionsTotalYearlyEmissionChanges as SelectedRegionsTotalYearlyEmissionChanges)
+      : null;
+
+  if (!selectedRegionsChangesData) {
+    return { SO2: 0, NOX: 0, CO2: 0, PM25: 0, VOCs: 0, NH3: 0 };
+  }
+
+  const result = Object.values(selectedRegionsChangesData).reduce(
+    (object, regionChanges) => {
+      ['CO2', 'NOX', 'SO2', 'PM25', 'VOCs', 'NH3'].forEach((item) => {
+        const pollutant = item as keyof typeof regionChanges.total;
+        const value = -1 * regionChanges.total[pollutant];
+        const result = pollutant === 'CO2' ? value / 2_000 : value;
+
+        object[pollutant] += result;
+      });
+
+      return object;
+    },
+    { SO2: 0, NOX: 0, CO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
+  );
+
+  return result;
+}
+
 function VehiclesEmissionsTableContent() {
-  const totalYearlyVehicleEmissionsChanges = useTypedSelector(
-    ({ transportation }) => transportation.totalYearlyEmissionChanges,
+  const selectedRegionsTotalYearlyEmissionChanges = useTypedSelector(
+    ({ transportation }) =>
+      transportation.selectedRegionsTotalYearlyEmissionChanges,
   );
   const combinedSectorsEmissionsData = useTypedSelector(
     ({ results }) => results.combinedSectorsEmissionsData,
   );
 
-  const annualEmissionsChanges = setAnnualEmissionsChanges(
+  const annualPower = setAnnualPowerEmissionsChanges({
     combinedSectorsEmissionsData,
-  );
+  });
 
-  const annualVehicleSO2 = -1 * totalYearlyVehicleEmissionsChanges.total.SO2;
-  const annualVehicleNOX = -1 * totalYearlyVehicleEmissionsChanges.total.NOX;
-  const annualVehicleCO2 = -1 * totalYearlyVehicleEmissionsChanges.total.CO2 / 2_000; // prettier-ignore
-  const annualVehiclePM25 = -1 * totalYearlyVehicleEmissionsChanges.total.PM25;
-  const annualVehicleVOCs = -1 * totalYearlyVehicleEmissionsChanges.total.VOCs;
-  const annualVehicleNH3 = -1 * totalYearlyVehicleEmissionsChanges.total.NH3;
-
-  const annualPowerSO2 = annualEmissionsChanges.so2;
-  const annualPowerNOX = annualEmissionsChanges.nox;
-  const annualPowerCO2 = annualEmissionsChanges.co2;
-  const annualPowerPM25 = annualEmissionsChanges.pm25;
-  const annualPowerVOCs = annualEmissionsChanges.vocs;
-  const annualPowerNH3 = annualEmissionsChanges.nh3;
+  const annualVehicle = setAnnualVehicleEmissionsChanges({
+    selectedRegionsTotalYearlyEmissionChanges,
+  });
 
   if (!combinedSectorsEmissionsData) return null;
 
@@ -100,13 +130,13 @@ function VehiclesEmissionsTableContent() {
                   </span>
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerSO2)}
+                  {formatNumber(annualPower.so2)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualVehicleSO2)}
+                  {formatNumber(annualVehicle.SO2)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerSO2 + annualVehicleSO2)}
+                  {formatNumber(annualPower.so2 + annualVehicle.SO2)}
                 </td>
               </tr>
 
@@ -117,13 +147,13 @@ function VehiclesEmissionsTableContent() {
                   </span>
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerNOX)}
+                  {formatNumber(annualPower.nox)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualVehicleNOX)}
+                  {formatNumber(annualVehicle.NOX)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerNOX + annualVehicleNOX)}
+                  {formatNumber(annualPower.nox + annualVehicle.NOX)}
                 </td>
               </tr>
 
@@ -134,13 +164,13 @@ function VehiclesEmissionsTableContent() {
                   </span>
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerCO2)}
+                  {formatNumber(annualPower.co2)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualVehicleCO2)}
+                  {formatNumber(annualVehicle.CO2)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerCO2 + annualVehicleCO2)}
+                  {formatNumber(annualPower.co2 + annualVehicle.CO2)}
                 </td>
               </tr>
 
@@ -151,13 +181,13 @@ function VehiclesEmissionsTableContent() {
                   </span>
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerPM25)}
+                  {formatNumber(annualPower.pm25)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualVehiclePM25)}
+                  {formatNumber(annualVehicle.PM25)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerPM25 + annualVehiclePM25)}
+                  {formatNumber(annualPower.pm25 + annualVehicle.PM25)}
                 </td>
               </tr>
 
@@ -168,13 +198,13 @@ function VehiclesEmissionsTableContent() {
                   </span>
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerVOCs)}
+                  {formatNumber(annualPower.vocs)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualVehicleVOCs)}
+                  {formatNumber(annualVehicle.VOCs)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerVOCs + annualVehicleVOCs)}
+                  {formatNumber(annualPower.vocs + annualVehicle.VOCs)}
                 </td>
               </tr>
 
@@ -185,13 +215,13 @@ function VehiclesEmissionsTableContent() {
                   </span>
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerNH3)}
+                  {formatNumber(annualPower.nh3)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualVehicleNH3)}
+                  {formatNumber(annualVehicle.NH3)}
                 </td>
                 <td className="font-mono-xs text-right">
-                  {formatNumber(annualPowerNH3 + annualVehicleNH3)}
+                  {formatNumber(annualPower.nh3 + annualVehicle.NH3)}
                 </td>
               </tr>
             </tbody>

--- a/client/src/app/redux/reducers/downloads.ts
+++ b/client/src/app/redux/reducers/downloads.ts
@@ -440,7 +440,7 @@ function createEmissionsFields(options: {
   }
 
   if (vehicleData && unit !== 'percent') {
-    result['Vehicles: Annual'] = vehicleData;
+    result['Vehicles: Annual'] = vehicleData.annual;
   }
 
   return result;
@@ -490,7 +490,7 @@ function formatCobraDownloadData(
 
             if (countyVehicleData !== null) {
               object.vehicle ??= { so2: 0, nox: 0, pm25: 0, vocs: 0, nh3: 0 };
-              object.vehicle[pollutant] = countyVehicleData;
+              object.vehicle[pollutant] = countyVehicleData.annual;
             }
           }
 

--- a/client/src/app/redux/reducers/eere.ts
+++ b/client/src/app/redux/reducers/eere.ts
@@ -33,7 +33,7 @@ import {
 
 type SelectOption = { id: string; name: string };
 
-type EereAction =
+type Action =
   | { type: 'eere/RESET_EERE_INPUTS' }
   | {
       type: 'eere/SET_EV_DEPLOYMENT_LOCATION_OPTIONS';
@@ -184,7 +184,7 @@ export type EEREInputs = {
     | 'iceReplacementVehicle']: string;
 };
 
-type EereState = {
+type State = {
   errors: (
     | EnergyEfficiencyFieldName
     | RenewableEnergyFieldName
@@ -228,7 +228,7 @@ const initialEEREInputs = {
   iceReplacementVehicle: initialICEReplacementVehicle,
 };
 
-const initialState: EereState = {
+const initialState: State = {
   errors: [],
   inputs: initialEEREInputs,
   selectOptions: {
@@ -258,9 +258,9 @@ const initialState: EereState = {
 };
 
 export default function reducer(
-  state: EereState = initialState,
-  action: EereAction,
-): EereState {
+  state: State = initialState,
+  action: Action,
+): State {
   switch (action.type) {
     case 'eere/RESET_EERE_INPUTS': {
       // initial state, excluding for selectOptions
@@ -947,7 +947,7 @@ export function calculateHourlyImpacts(): AppThunk {
     const {
       dailyStats,
       hourlyEVChargingPercentages,
-      monthlyDailyEVEnergyUsage,
+      selectedRegionsMonthlyDailyEVEnergyUsage,
     } = transportation;
     const { inputs } = eere;
 
@@ -1085,10 +1085,11 @@ export function calculateHourlyImpacts(): AppThunk {
         });
 
       const hourlyEVLoad = calculateHourlyEVLoad({
+        regionId: region.id,
         regionalLoad,
         dailyStats,
         hourlyEVChargingPercentages,
-        monthlyDailyEVEnergyUsage,
+        selectedRegionsMonthlyDailyEVEnergyUsage,
       });
 
       const topPercentGeneration = calculateTopPercentGeneration({

--- a/client/src/app/redux/reducers/results.ts
+++ b/client/src/app/redux/reducers/results.ts
@@ -145,7 +145,10 @@ export function resetResults(): Action {
 export function fetchEmissionsChanges(): AppThunk {
   return (dispatch, getState) => {
     const { api, transportation, eere } = getState();
-    const { vehicleEmissionChangesByGeography } = transportation;
+    const {
+      selectedRegionsTotalMonthlyEmissionChanges,
+      vehicleEmissionChangesByGeography,
+    } = transportation;
     const { hourlyImpacts } = eere;
 
     dispatch({ type: 'results/FETCH_EMISSIONS_CHANGES_REQUEST' });
@@ -189,6 +192,7 @@ export function fetchEmissionsChanges(): AppThunk {
         // prettier-ignore
         const combinedSectorsEmissionsData = createCombinedSectorsEmissionsData({
           aggregatedEmissionsData,
+          selectedRegionsTotalMonthlyEmissionChanges,
           vehicleEmissionChangesByGeography,
         });
 

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -19,7 +19,7 @@ import type {
   MonthlyDailyEVEnergyUsage,
   SelectedRegionsMonthlyEmissionRates,
   SelectedRegionsMonthlyEmissionChanges,
-  TotalMonthlyEmissionChanges,
+  SelectedRegionsTotalMonthlyEmissionChanges,
   TotalYearlyEmissionChanges,
   VehicleEmissionChangesByGeography,
   VehicleSalesAndStock,
@@ -47,7 +47,7 @@ import {
   calculateMonthlyDailyEVEnergyUsage,
   calculateSelectedRegionsMonthlyEmissionRates,
   calculateSelectedRegionsMonthlyEmissionChanges,
-  calculateTotalMonthlyEmissionChanges,
+  calculateSelectedRegionsTotalMonthlyEmissionChanges,
   calculateTotalYearlyEmissionChanges,
   calculateVehicleEmissionChangesByGeography,
   calculateVehicleSalesAndStock,
@@ -150,8 +150,10 @@ type Action =
       };
     }
   | {
-      type: 'transportation/SET_TOTAL_MONTHLY_EMISSION_CHANGES';
-      payload: { totalMonthlyEmissionChanges: TotalMonthlyEmissionChanges };
+      type: 'transportation/SET_SELECTED_REGIONS_TOTAL_MONTHLY_EMISSION_CHANGES';
+      payload: {
+        selectedRegionsTotalMonthlyEmissionChanges: SelectedRegionsTotalMonthlyEmissionChanges;
+      };
     }
   | {
       type: 'transportation/SET_TOTAL_YEARLY_EMISSION_CHANGES';
@@ -200,7 +202,7 @@ type State = {
   monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage;
   selectedRegionsMonthlyEmissionRates: SelectedRegionsMonthlyEmissionRates | {};
   selectedRegionsMonthlyEmissionChanges: SelectedRegionsMonthlyEmissionChanges | {}; // prettier-ignore
-  totalMonthlyEmissionChanges: TotalMonthlyEmissionChanges;
+  selectedRegionsTotalMonthlyEmissionChanges: SelectedRegionsTotalMonthlyEmissionChanges | {}; // prettier-ignore
   totalYearlyEmissionChanges: TotalYearlyEmissionChanges;
   vehicleEmissionChangesByGeography: VehicleEmissionChangesByGeography | {};
   vehicleSalesAndStock: VehicleSalesAndStock;
@@ -244,7 +246,7 @@ const initialState: State = {
   monthlyDailyEVEnergyUsage: {},
   selectedRegionsMonthlyEmissionRates: {},
   selectedRegionsMonthlyEmissionChanges: {},
-  totalMonthlyEmissionChanges: {},
+  selectedRegionsTotalMonthlyEmissionChanges: {},
   totalYearlyEmissionChanges: {
     cars: { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
     trucks: { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
@@ -429,12 +431,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_TOTAL_MONTHLY_EMISSION_CHANGES': {
-      const { totalMonthlyEmissionChanges } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_TOTAL_MONTHLY_EMISSION_CHANGES': {
+      const { selectedRegionsTotalMonthlyEmissionChanges } = action.payload;
 
       return {
         ...state,
-        totalMonthlyEmissionChanges,
+        selectedRegionsTotalMonthlyEmissionChanges,
       };
     }
 
@@ -873,13 +875,14 @@ export function setEmissionChanges(): AppThunk {
         selectedRegionsMonthlyEmissionRates,
       });
 
-    const totalMonthlyEmissionChanges = calculateTotalMonthlyEmissionChanges({
-      selectedRegionsMonthlyEmissionChanges,
-    });
+    const selectedRegionsTotalMonthlyEmissionChanges =
+      calculateSelectedRegionsTotalMonthlyEmissionChanges({
+        selectedRegionsMonthlyEmissionChanges,
+      });
 
-    const totalYearlyEmissionChanges = calculateTotalYearlyEmissionChanges(
-      totalMonthlyEmissionChanges,
-    );
+    const totalYearlyEmissionChanges = calculateTotalYearlyEmissionChanges({
+      selectedRegionsTotalMonthlyEmissionChanges,
+    });
 
     const geographicFocus = geography.focus;
 
@@ -911,8 +914,8 @@ export function setEmissionChanges(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_TOTAL_MONTHLY_EMISSION_CHANGES',
-      payload: { totalMonthlyEmissionChanges },
+      type: 'transportation/SET_SELECTED_REGIONS_TOTAL_MONTHLY_EMISSION_CHANGES',
+      payload: { selectedRegionsTotalMonthlyEmissionChanges },
     });
 
     dispatch({

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -8,7 +8,7 @@ import type {
   SelectedRegionsStatesVMTPercentages,
   SelectedRegionsVMTPercentagesPerVehicleType,
   SelectedRegionsAverageVMTPerYear,
-  MonthlyVMTPerVehicleType,
+  SelectedRegionsMonthlyVMTPerVehicleType,
   EVEfficiencyPerVehicleType,
   DailyStats,
   MonthlyStats,
@@ -36,7 +36,7 @@ import {
   calculateSelectedRegionsStatesVMTPercentages,
   calculateSelectedRegionsVMTPercentagesPerVehicleType,
   calculateSelectedRegionsAverageVMTPerYear,
-  calculateMonthlyVMTPerVehicleType,
+  calculateSelectedRegionsMonthlyVMTPerVehicleType,
   calculateEVEfficiencyPerVehicleType,
   calculateDailyStats,
   calculateMonthlyStats,
@@ -100,8 +100,10 @@ type Action =
       };
     }
   | {
-      type: 'transportation/SET_MONTHLY_VMT_PER_VEHICLE_TYPE';
-      payload: { monthlyVMTPerVehicleType: MonthlyVMTPerVehicleType };
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_VMT_PER_VEHICLE_TYPE';
+      payload: {
+        selectedRegionsMonthlyVMTPerVehicleType: SelectedRegionsMonthlyVMTPerVehicleType;
+      };
     }
   | {
       type: 'transportation/SET_EV_EFFICIENCY_PER_VEHICLE_TYPE';
@@ -183,7 +185,7 @@ type State = {
   selectedRegionsStatesVMTPercentages: SelectedRegionsStatesVMTPercentages | {};
   selectedRegionsVMTPercentagesPerVehicleType: SelectedRegionsVMTPercentagesPerVehicleType | {}; // prettier-ignore
   selectedRegionsAverageVMTPerYear: SelectedRegionsAverageVMTPerYear | {};
-  monthlyVMTPerVehicleType: MonthlyVMTPerVehicleType;
+  selectedRegionsMonthlyVMTPerVehicleType: SelectedRegionsMonthlyVMTPerVehicleType | {}; // prettier-ignore
   evEfficiencyPerVehicleType: EVEfficiencyPerVehicleType;
   dailyStats: DailyStats;
   monthlyStats: MonthlyStats;
@@ -211,7 +213,7 @@ const initialState: State = {
   selectedRegionsStatesVMTPercentages: {},
   selectedRegionsVMTPercentagesPerVehicleType: {},
   selectedRegionsAverageVMTPerYear: {},
-  monthlyVMTPerVehicleType: {},
+  selectedRegionsMonthlyVMTPerVehicleType: {},
   evEfficiencyPerVehicleType: {
     batteryEVCars: 0,
     hybridEVCars: 0,
@@ -333,12 +335,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_MONTHLY_VMT_PER_VEHICLE_TYPE': {
-      const { monthlyVMTPerVehicleType } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_MONTHLY_VMT_PER_VEHICLE_TYPE': {
+      const { selectedRegionsMonthlyVMTPerVehicleType } = action.payload;
 
       return {
         ...state,
-        monthlyVMTPerVehicleType,
+        selectedRegionsMonthlyVMTPerVehicleType,
       };
     }
 
@@ -589,10 +591,11 @@ export function setSelectedGeographyVMTData(): AppThunk {
         selectedRegionsVMTPercentagesPerVehicleType,
       });
 
-    const monthlyVMTPerVehicleType = calculateMonthlyVMTPerVehicleType({
-      selectedRegionsAverageVMTPerYear,
-      monthlyVMTTotalsAndPercentages,
-    });
+    const selectedRegionsMonthlyVMTPerVehicleType =
+      calculateSelectedRegionsMonthlyVMTPerVehicleType({
+        selectedRegionsAverageVMTPerYear,
+        monthlyVMTTotalsAndPercentages,
+      });
 
     dispatch({
       type: 'transportation/SET_SELECTED_REGIONS_STATES_VMT_PERCENTAGES',
@@ -610,17 +613,17 @@ export function setSelectedGeographyVMTData(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_MONTHLY_VMT_PER_VEHICLE_TYPE',
-      payload: { monthlyVMTPerVehicleType },
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_VMT_PER_VEHICLE_TYPE',
+      payload: { selectedRegionsMonthlyVMTPerVehicleType },
     });
 
-    // NOTE: `monthlyEVEnergyUsageGW` uses `monthlyVMTPerVehicleType`
+    // NOTE: `monthlyEVEnergyUsageGW` uses `selectedRegionsMonthlyVMTPerVehicleType`
     dispatch(setMonthlyEVEnergyUsage());
 
     // NOTE: `monthlyEmissionRates` uses `selectedGeographyStatesVMTPercentages`
     dispatch(setMonthlyEmissionRates());
 
-    // NOTE: `monthlyEmissionChanges` uses `monthlyVMTPerVehicleType`
+    // NOTE: `monthlyEmissionChanges` uses `selectedRegionsMonthlyVMTPerVehicleType`
     dispatch(setEmissionChanges());
   };
 }
@@ -737,13 +740,13 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
   return (dispatch, getState) => {
     const { transportation } = getState();
     const {
-      monthlyVMTPerVehicleType,
+      selectedRegionsMonthlyVMTPerVehicleType,
       evEfficiencyPerVehicleType,
       vehiclesDisplaced,
     } = transportation;
 
     const monthlyEVEnergyUsageGW = calculateMonthlyEVEnergyUsageGW({
-      monthlyVMTPerVehicleType,
+      selectedRegionsMonthlyVMTPerVehicleType,
       evEfficiencyPerVehicleType,
       vehiclesDisplaced,
     });
@@ -851,7 +854,7 @@ export function setEmissionChanges(): AppThunk {
     const { countiesByGeography, regionalScalingFactors } = geography;
     const {
       vmtPerVehicleTypeByGeography,
-      monthlyVMTPerVehicleType,
+      selectedRegionsMonthlyVMTPerVehicleType,
       vehiclesDisplaced,
       monthlyEmissionRates,
     } = transportation;
@@ -859,7 +862,7 @@ export function setEmissionChanges(): AppThunk {
     const { evDeploymentLocation } = eere.inputs;
 
     const monthlyEmissionChanges = calculateMonthlyEmissionChanges({
-      monthlyVMTPerVehicleType,
+      selectedRegionsMonthlyVMTPerVehicleType,
       vehiclesDisplaced,
       monthlyEmissionRates,
     });

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -572,8 +572,8 @@ export function setSelectedGeographyVMTData(): AppThunk {
 
     const geographicFocus = geography.focus;
 
-    const selectedRegionName =
-      Object.values(geography.regions).find((r) => r.selected)?.name || '';
+    const selectedRegionId =
+      Object.values(geography.regions).find((r) => r.selected)?.id || '';
 
     const selectedStateId =
       Object.values(geography.states).find((s) => s.selected)?.id || '';
@@ -581,7 +581,7 @@ export function setSelectedGeographyVMTData(): AppThunk {
     const selectedGeographyStatesVMTPercentages =
       calculateSelectedGeographyStatesVMTPercentages({
         geographicFocus,
-        selectedRegionName,
+        selectedRegionId,
         selectedStateId,
         vmtAllocationTotalsAndPercentages,
       });

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -815,8 +815,6 @@ export function setMonthlyDailyEVEnergyUsage(): AppThunk {
         monthlyStats,
       });
 
-    console.log(selectedRegionsMonthlyDailyEVEnergyUsage);
-
     dispatch({
       type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_DAILY_EV_ENERGY_USAGE',
       payload: { selectedRegionsMonthlyDailyEVEnergyUsage },

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -14,7 +14,7 @@ import type {
   MonthlyStats,
   VehiclesDisplaced,
   SelectedRegionsMonthlyEVEnergyUsageGW,
-  MonthlyEVEnergyUsageMW,
+  SelectedRegionsMonthlyEVEnergyUsageMW,
   TotalYearlyEVEnergyUsage,
   MonthlyDailyEVEnergyUsage,
   SelectedRegionsMonthlyEmissionRates,
@@ -42,7 +42,7 @@ import {
   calculateMonthlyStats,
   calculateVehiclesDisplaced,
   calculateSelectedRegionsMonthlyEVEnergyUsageGW,
-  calculateMonthlyEVEnergyUsageMW,
+  calculateSelectedRegionsMonthlyEVEnergyUsageMW,
   calculateTotalYearlyEVEnergyUsage,
   calculateMonthlyDailyEVEnergyUsage,
   calculateSelectedRegionsMonthlyEmissionRates,
@@ -128,8 +128,10 @@ type Action =
       };
     }
   | {
-      type: 'transportation/SET_MONTHLY_EV_ENERGY_USAGE_MW';
-      payload: { monthlyEVEnergyUsageMW: MonthlyEVEnergyUsageMW };
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EV_ENERGY_USAGE_MW';
+      payload: {
+        selectedRegionsMonthlyEVEnergyUsageMW: SelectedRegionsMonthlyEVEnergyUsageMW;
+      };
     }
   | {
       type: 'transportation/SET_TOTAL_YEARLY_EV_ENERGY_USAGE';
@@ -201,7 +203,7 @@ type State = {
   monthlyStats: MonthlyStats;
   vehiclesDisplaced: VehiclesDisplaced;
   selectedRegionsMonthlyEVEnergyUsageGW: SelectedRegionsMonthlyEVEnergyUsageGW | {}; // prettier-ignore
-  monthlyEVEnergyUsageMW: MonthlyEVEnergyUsageMW;
+  selectedRegionsMonthlyEVEnergyUsageMW: SelectedRegionsMonthlyEVEnergyUsageMW | {}; // prettier-ignore
   totalYearlyEVEnergyUsage: TotalYearlyEVEnergyUsage;
   monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage;
   selectedRegionsMonthlyEmissionRates: SelectedRegionsMonthlyEmissionRates | {};
@@ -245,7 +247,7 @@ const initialState: State = {
     schoolBuses: 0,
   },
   selectedRegionsMonthlyEVEnergyUsageGW: {},
-  monthlyEVEnergyUsageMW: {},
+  selectedRegionsMonthlyEVEnergyUsageMW: {},
   totalYearlyEVEnergyUsage: 0,
   monthlyDailyEVEnergyUsage: {},
   selectedRegionsMonthlyEmissionRates: {},
@@ -393,12 +395,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_MONTHLY_EV_ENERGY_USAGE_MW': {
-      const { monthlyEVEnergyUsageMW } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_MONTHLY_EV_ENERGY_USAGE_MW': {
+      const { selectedRegionsMonthlyEVEnergyUsageMW } = action.payload;
 
       return {
         ...state,
-        monthlyEVEnergyUsageMW,
+        selectedRegionsMonthlyEVEnergyUsageMW,
       };
     }
 
@@ -756,9 +758,10 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
         vehiclesDisplaced,
       });
 
-    const monthlyEVEnergyUsageMW = calculateMonthlyEVEnergyUsageMW({
-      selectedRegionsMonthlyEVEnergyUsageGW,
-    });
+    const selectedRegionsMonthlyEVEnergyUsageMW =
+      calculateSelectedRegionsMonthlyEVEnergyUsageMW({
+        selectedRegionsMonthlyEVEnergyUsageGW,
+      });
 
     const totalYearlyEVEnergyUsage = calculateTotalYearlyEVEnergyUsage({
       selectedRegionsMonthlyEVEnergyUsageGW,
@@ -770,8 +773,8 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_MONTHLY_EV_ENERGY_USAGE_MW',
-      payload: { monthlyEVEnergyUsageMW },
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EV_ENERGY_USAGE_MW',
+      payload: { selectedRegionsMonthlyEVEnergyUsageMW },
     });
 
     dispatch({
@@ -779,7 +782,7 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
       payload: { totalYearlyEVEnergyUsage },
     });
 
-    // NOTE: `monthlyDailyEVEnergyUsage` uses `monthlyEVEnergyUsageMW`
+    // NOTE: `monthlyDailyEVEnergyUsage` uses `selectedRegionsMonthlyEVEnergyUsageMW`
     dispatch(setMonthlyDailyEVEnergyUsage());
   };
 }
@@ -798,10 +801,11 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
 export function setMonthlyDailyEVEnergyUsage(): AppThunk {
   return (dispatch, getState) => {
     const { transportation } = getState();
-    const { monthlyStats, monthlyEVEnergyUsageMW } = transportation;
+    const { monthlyStats, selectedRegionsMonthlyEVEnergyUsageMW } =
+      transportation;
 
     const monthlyDailyEVEnergyUsage = calculateMonthlyDailyEVEnergyUsage({
-      monthlyEVEnergyUsageMW,
+      selectedRegionsMonthlyEVEnergyUsageMW,
       monthlyStats,
     });
 

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -13,7 +13,7 @@ import type {
   DailyStats,
   MonthlyStats,
   VehiclesDisplaced,
-  MonthlyEVEnergyUsageGW,
+  SelectedRegionsMonthlyEVEnergyUsageGW,
   MonthlyEVEnergyUsageMW,
   TotalYearlyEVEnergyUsage,
   MonthlyDailyEVEnergyUsage,
@@ -41,7 +41,7 @@ import {
   calculateDailyStats,
   calculateMonthlyStats,
   calculateVehiclesDisplaced,
-  calculateMonthlyEVEnergyUsageGW,
+  calculateSelectedRegionsMonthlyEVEnergyUsageGW,
   calculateMonthlyEVEnergyUsageMW,
   calculateTotalYearlyEVEnergyUsage,
   calculateMonthlyDailyEVEnergyUsage,
@@ -122,8 +122,10 @@ type Action =
       payload: { vehiclesDisplaced: VehiclesDisplaced };
     }
   | {
-      type: 'transportation/SET_MONTHLY_EV_ENERGY_USAGE_GW';
-      payload: { monthlyEVEnergyUsageGW: MonthlyEVEnergyUsageGW };
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EV_ENERGY_USAGE_GW';
+      payload: {
+        selectedRegionsMonthlyEVEnergyUsageGW: SelectedRegionsMonthlyEVEnergyUsageGW;
+      };
     }
   | {
       type: 'transportation/SET_MONTHLY_EV_ENERGY_USAGE_MW';
@@ -198,7 +200,7 @@ type State = {
   dailyStats: DailyStats;
   monthlyStats: MonthlyStats;
   vehiclesDisplaced: VehiclesDisplaced;
-  monthlyEVEnergyUsageGW: MonthlyEVEnergyUsageGW;
+  selectedRegionsMonthlyEVEnergyUsageGW: SelectedRegionsMonthlyEVEnergyUsageGW | {}; // prettier-ignore
   monthlyEVEnergyUsageMW: MonthlyEVEnergyUsageMW;
   totalYearlyEVEnergyUsage: TotalYearlyEVEnergyUsage;
   monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage;
@@ -242,7 +244,7 @@ const initialState: State = {
     transitBusesGasoline: 0,
     schoolBuses: 0,
   },
-  monthlyEVEnergyUsageGW: {},
+  selectedRegionsMonthlyEVEnergyUsageGW: {},
   monthlyEVEnergyUsageMW: {},
   totalYearlyEVEnergyUsage: 0,
   monthlyDailyEVEnergyUsage: {},
@@ -382,12 +384,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_MONTHLY_EV_ENERGY_USAGE_GW': {
-      const { monthlyEVEnergyUsageGW } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_MONTHLY_EV_ENERGY_USAGE_GW': {
+      const { selectedRegionsMonthlyEVEnergyUsageGW } = action.payload;
 
       return {
         ...state,
-        monthlyEVEnergyUsageGW,
+        selectedRegionsMonthlyEVEnergyUsageGW,
       };
     }
 
@@ -747,23 +749,24 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
       vehiclesDisplaced,
     } = transportation;
 
-    const monthlyEVEnergyUsageGW = calculateMonthlyEVEnergyUsageGW({
-      selectedRegionsMonthlyVMTPerVehicleType,
-      evEfficiencyPerVehicleType,
-      vehiclesDisplaced,
+    const selectedRegionsMonthlyEVEnergyUsageGW =
+      calculateSelectedRegionsMonthlyEVEnergyUsageGW({
+        selectedRegionsMonthlyVMTPerVehicleType,
+        evEfficiencyPerVehicleType,
+        vehiclesDisplaced,
+      });
+
+    const monthlyEVEnergyUsageMW = calculateMonthlyEVEnergyUsageMW({
+      selectedRegionsMonthlyEVEnergyUsageGW,
     });
 
-    const monthlyEVEnergyUsageMW = calculateMonthlyEVEnergyUsageMW(
-      monthlyEVEnergyUsageGW,
-    );
-
-    const totalYearlyEVEnergyUsage = calculateTotalYearlyEVEnergyUsage(
-      monthlyEVEnergyUsageGW,
-    );
+    const totalYearlyEVEnergyUsage = calculateTotalYearlyEVEnergyUsage({
+      selectedRegionsMonthlyEVEnergyUsageGW,
+    });
 
     dispatch({
-      type: 'transportation/SET_MONTHLY_EV_ENERGY_USAGE_GW',
-      payload: { monthlyEVEnergyUsageGW },
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EV_ENERGY_USAGE_GW',
+      payload: { selectedRegionsMonthlyEVEnergyUsageGW },
     });
 
     dispatch({

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -15,7 +15,7 @@ import type {
   VehiclesDisplaced,
   SelectedRegionsMonthlyEVEnergyUsageGW,
   SelectedRegionsMonthlyEVEnergyUsageMW,
-  TotalYearlyEVEnergyUsage,
+  SelectedRegionsTotalYearlyEVEnergyUsage,
   MonthlyDailyEVEnergyUsage,
   SelectedRegionsMonthlyEmissionRates,
   SelectedRegionsMonthlyEmissionChanges,
@@ -43,7 +43,7 @@ import {
   calculateVehiclesDisplaced,
   calculateSelectedRegionsMonthlyEVEnergyUsageGW,
   calculateSelectedRegionsMonthlyEVEnergyUsageMW,
-  calculateTotalYearlyEVEnergyUsage,
+  calculateSelectedRegionsTotalYearlyEVEnergyUsage,
   calculateMonthlyDailyEVEnergyUsage,
   calculateSelectedRegionsMonthlyEmissionRates,
   calculateSelectedRegionsMonthlyEmissionChanges,
@@ -134,8 +134,10 @@ type Action =
       };
     }
   | {
-      type: 'transportation/SET_TOTAL_YEARLY_EV_ENERGY_USAGE';
-      payload: { totalYearlyEVEnergyUsage: TotalYearlyEVEnergyUsage };
+      type: 'transportation/SET_SELECTED_REGIONS_TOTAL_YEARLY_EV_ENERGY_USAGE';
+      payload: {
+        selectedRegionsTotalYearlyEVEnergyUsage: SelectedRegionsTotalYearlyEVEnergyUsage;
+      };
     }
   | {
       type: 'transportation/SET_MONTHLY_DAILY_EV_ENERGY_USAGE';
@@ -204,7 +206,7 @@ type State = {
   vehiclesDisplaced: VehiclesDisplaced;
   selectedRegionsMonthlyEVEnergyUsageGW: SelectedRegionsMonthlyEVEnergyUsageGW | {}; // prettier-ignore
   selectedRegionsMonthlyEVEnergyUsageMW: SelectedRegionsMonthlyEVEnergyUsageMW | {}; // prettier-ignore
-  totalYearlyEVEnergyUsage: TotalYearlyEVEnergyUsage;
+  selectedRegionsTotalYearlyEVEnergyUsage: SelectedRegionsTotalYearlyEVEnergyUsage | {}; // prettier-ignore
   monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage;
   selectedRegionsMonthlyEmissionRates: SelectedRegionsMonthlyEmissionRates | {};
   selectedRegionsMonthlyEmissionChanges: SelectedRegionsMonthlyEmissionChanges | {}; // prettier-ignore
@@ -248,7 +250,7 @@ const initialState: State = {
   },
   selectedRegionsMonthlyEVEnergyUsageGW: {},
   selectedRegionsMonthlyEVEnergyUsageMW: {},
-  totalYearlyEVEnergyUsage: 0,
+  selectedRegionsTotalYearlyEVEnergyUsage: {},
   monthlyDailyEVEnergyUsage: {},
   selectedRegionsMonthlyEmissionRates: {},
   selectedRegionsMonthlyEmissionChanges: {},
@@ -458,12 +460,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_TOTAL_YEARLY_EV_ENERGY_USAGE': {
-      const { totalYearlyEVEnergyUsage } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_TOTAL_YEARLY_EV_ENERGY_USAGE': {
+      const { selectedRegionsTotalYearlyEVEnergyUsage } = action.payload;
 
       return {
         ...state,
-        totalYearlyEVEnergyUsage,
+        selectedRegionsTotalYearlyEVEnergyUsage,
       };
     }
 
@@ -763,9 +765,10 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
         selectedRegionsMonthlyEVEnergyUsageGW,
       });
 
-    const totalYearlyEVEnergyUsage = calculateTotalYearlyEVEnergyUsage({
-      selectedRegionsMonthlyEVEnergyUsageGW,
-    });
+    const selectedRegionsTotalYearlyEVEnergyUsage =
+      calculateSelectedRegionsTotalYearlyEVEnergyUsage({
+        selectedRegionsMonthlyEVEnergyUsageGW,
+      });
 
     dispatch({
       type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EV_ENERGY_USAGE_GW',
@@ -778,8 +781,8 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_TOTAL_YEARLY_EV_ENERGY_USAGE',
-      payload: { totalYearlyEVEnergyUsage },
+      type: 'transportation/SET_SELECTED_REGIONS_TOTAL_YEARLY_EV_ENERGY_USAGE',
+      payload: { selectedRegionsTotalYearlyEVEnergyUsage },
     });
 
     // NOTE: `monthlyDailyEVEnergyUsage` uses `selectedRegionsMonthlyEVEnergyUsageMW`

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -6,7 +6,7 @@ import type {
   MonthlyVMTTotalsAndPercentages,
   HourlyEVChargingPercentages,
   SelectedRegionsStatesVMTPercentages,
-  SelectedGeographyVMTPercentagesPerVehicleType,
+  SelectedRegionsVMTPercentagesPerVehicleType,
   SelectedGeographyAverageVMTPerYear,
   MonthlyVMTPerVehicleType,
   EVEfficiencyPerVehicleType,
@@ -34,7 +34,7 @@ import {
   calculateMonthlyVMTTotalsAndPercentages,
   calculateHourlyEVChargingPercentages,
   calculateSelectedRegionsStatesVMTPercentages,
-  calculateSelectedGeographyVMTPercentagesPerVehicleType,
+  calculateSelectedRegionsVMTPercentagesPerVehicleType,
   calculateSelectedGeographyAverageVMTPerYear,
   calculateMonthlyVMTPerVehicleType,
   calculateEVEfficiencyPerVehicleType,
@@ -56,7 +56,7 @@ import {
 } from 'app/calculations/transportation';
 import type { RegionId } from 'app/config';
 
-type TransportationAction =
+type Action =
   | {
       type: 'transportation/SET_VMT_PER_VEHICLE_TYPE_BY_GEOGRAPHY';
       payload: { vmtPerVehicleTypeByGeography: VMTPerVehicleTypeByGeography };
@@ -88,9 +88,9 @@ type TransportationAction =
       };
     }
   | {
-      type: 'transportation/SET_SELECTED_GEOGRAPHY_VMT_PERCENTAGES_PER_VEHICLE_TYPE';
+      type: 'transportation/SET_SELECTED_REGIONS_VMT_PERCENTAGES_PER_VEHICLE_TYPE';
       payload: {
-        selectedGeographyVMTPercentagesPerVehicleType: SelectedGeographyVMTPercentagesPerVehicleType;
+        selectedRegionsVMTPercentagesPerVehicleType: SelectedRegionsVMTPercentagesPerVehicleType;
       };
     }
   | {
@@ -174,14 +174,14 @@ type TransportationAction =
       };
     };
 
-type TransportationState = {
+type State = {
   vmtPerVehicleTypeByGeography: VMTPerVehicleTypeByGeography | {};
   vmtAllocationTotalsAndPercentages: VMTAllocationTotalsAndPercentages | {};
   vmtAllocationPerVehicle: VMTAllocationPerVehicle | {};
   monthlyVMTTotalsAndPercentages: MonthlyVMTTotalsAndPercentages;
   hourlyEVChargingPercentages: HourlyEVChargingPercentages;
   selectedRegionsStatesVMTPercentages: SelectedRegionsStatesVMTPercentages | {};
-  selectedGeographyVMTPercentagesPerVehicleType: SelectedGeographyVMTPercentagesPerVehicleType;
+  selectedRegionsVMTPercentagesPerVehicleType: SelectedRegionsVMTPercentagesPerVehicleType | {}; // prettier-ignore
   selectedGeographyAverageVMTPerYear: SelectedGeographyAverageVMTPerYear;
   monthlyVMTPerVehicleType: MonthlyVMTPerVehicleType;
   evEfficiencyPerVehicleType: EVEfficiencyPerVehicleType;
@@ -202,17 +202,14 @@ type TransportationState = {
   evDeploymentLocationHistoricalEERE: EVDeploymentLocationHistoricalEERE;
 };
 
-const initialState: TransportationState = {
+const initialState: State = {
   vmtPerVehicleTypeByGeography: {},
   vmtAllocationTotalsAndPercentages: {},
   vmtAllocationPerVehicle: {},
   monthlyVMTTotalsAndPercentages: {},
   hourlyEVChargingPercentages: {},
   selectedRegionsStatesVMTPercentages: {},
-  selectedGeographyVMTPercentagesPerVehicleType: {
-    vmtPerLDVPercent: 0,
-    vmtPerBusPercent: 0,
-  },
+  selectedRegionsVMTPercentagesPerVehicleType: {},
   selectedGeographyAverageVMTPerYear: {
     cars: 0,
     trucks: 0,
@@ -265,9 +262,9 @@ const initialState: TransportationState = {
 };
 
 export default function reducer(
-  state: TransportationState = initialState,
-  action: TransportationAction,
-): TransportationState {
+  state: State = initialState,
+  action: Action,
+): State {
   switch (action.type) {
     case 'transportation/SET_VMT_PER_VEHICLE_TYPE_BY_GEOGRAPHY': {
       const { vmtPerVehicleTypeByGeography } = action.payload;
@@ -323,12 +320,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_SELECTED_GEOGRAPHY_VMT_PERCENTAGES_PER_VEHICLE_TYPE': {
-      const { selectedGeographyVMTPercentagesPerVehicleType } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_VMT_PERCENTAGES_PER_VEHICLE_TYPE': {
+      const { selectedRegionsVMTPercentagesPerVehicleType } = action.payload;
 
       return {
         ...state,
-        selectedGeographyVMTPercentagesPerVehicleType,
+        selectedRegionsVMTPercentagesPerVehicleType,
       };
     }
 
@@ -586,15 +583,15 @@ export function setSelectedGeographyVMTData(): AppThunk {
         vmtAllocationTotalsAndPercentages,
       });
 
-    const selectedGeographyVMTPercentagesPerVehicleType =
-      calculateSelectedGeographyVMTPercentagesPerVehicleType({
+    const selectedRegionsVMTPercentagesPerVehicleType =
+      calculateSelectedRegionsVMTPercentagesPerVehicleType({
         selectedRegionsStatesVMTPercentages,
         vmtAllocationPerVehicle,
       });
 
     const selectedGeographyAverageVMTPerYear =
       calculateSelectedGeographyAverageVMTPerYear(
-        selectedGeographyVMTPercentagesPerVehicleType,
+        selectedRegionsVMTPercentagesPerVehicleType,
       );
 
     const monthlyVMTPerVehicleType = calculateMonthlyVMTPerVehicleType({
@@ -608,8 +605,8 @@ export function setSelectedGeographyVMTData(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_SELECTED_GEOGRAPHY_VMT_PERCENTAGES_PER_VEHICLE_TYPE',
-      payload: { selectedGeographyVMTPercentagesPerVehicleType },
+      type: 'transportation/SET_SELECTED_REGIONS_VMT_PERCENTAGES_PER_VEHICLE_TYPE',
+      payload: { selectedRegionsVMTPercentagesPerVehicleType },
     });
 
     dispatch({

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -17,7 +17,7 @@ import type {
   MonthlyEVEnergyUsageMW,
   TotalYearlyEVEnergyUsage,
   MonthlyDailyEVEnergyUsage,
-  MonthlyEmissionRates,
+  SelectedRegionsMonthlyEmissionRates,
   MonthlyEmissionChanges,
   TotalMonthlyEmissionChanges,
   TotalYearlyEmissionChanges,
@@ -45,7 +45,7 @@ import {
   calculateMonthlyEVEnergyUsageMW,
   calculateTotalYearlyEVEnergyUsage,
   calculateMonthlyDailyEVEnergyUsage,
-  calculateMonthlyEmissionRates,
+  calculateSelectedRegionsMonthlyEmissionRates,
   calculateMonthlyEmissionChanges,
   calculateTotalMonthlyEmissionChanges,
   calculateTotalYearlyEmissionChanges,
@@ -138,8 +138,10 @@ type Action =
       payload: { monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage };
     }
   | {
-      type: 'transportation/SET_MONTHLY_EMISSION_RATES';
-      payload: { monthlyEmissionRates: MonthlyEmissionRates };
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EMISSION_RATES';
+      payload: {
+        selectedRegionsMonthlyEmissionRates: SelectedRegionsMonthlyEmissionRates;
+      };
     }
   | {
       type: 'transportation/SET_MONTHLY_EMISSION_CHANGES';
@@ -194,7 +196,7 @@ type State = {
   monthlyEVEnergyUsageMW: MonthlyEVEnergyUsageMW;
   totalYearlyEVEnergyUsage: TotalYearlyEVEnergyUsage;
   monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage;
-  monthlyEmissionRates: MonthlyEmissionRates;
+  selectedRegionsMonthlyEmissionRates: SelectedRegionsMonthlyEmissionRates | {};
   monthlyEmissionChanges: MonthlyEmissionChanges;
   totalMonthlyEmissionChanges: TotalMonthlyEmissionChanges;
   totalYearlyEmissionChanges: TotalYearlyEmissionChanges;
@@ -238,7 +240,7 @@ const initialState: State = {
   monthlyEVEnergyUsageMW: {},
   totalYearlyEVEnergyUsage: 0,
   monthlyDailyEVEnergyUsage: {},
-  monthlyEmissionRates: {},
+  selectedRegionsMonthlyEmissionRates: {},
   monthlyEmissionChanges: {},
   totalMonthlyEmissionChanges: {},
   totalYearlyEmissionChanges: {
@@ -407,12 +409,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_MONTHLY_EMISSION_RATES': {
-      const { monthlyEmissionRates } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_MONTHLY_EMISSION_RATES': {
+      const { selectedRegionsMonthlyEmissionRates } = action.payload;
 
       return {
         ...state,
-        monthlyEmissionRates,
+        selectedRegionsMonthlyEmissionRates,
       };
     }
 
@@ -620,7 +622,7 @@ export function setSelectedGeographyVMTData(): AppThunk {
     // NOTE: `monthlyEVEnergyUsageGW` uses `selectedRegionsMonthlyVMTPerVehicleType`
     dispatch(setMonthlyEVEnergyUsage());
 
-    // NOTE: `monthlyEmissionRates` uses `selectedGeographyStatesVMTPercentages`
+    // NOTE: `selectedRegionsMonthlyEmissionRates` uses `selectedGeographyStatesVMTPercentages`
     dispatch(setMonthlyEmissionRates());
 
     // NOTE: `monthlyEmissionChanges` uses `selectedRegionsMonthlyVMTPerVehicleType`
@@ -823,19 +825,20 @@ export function setMonthlyEmissionRates(): AppThunk {
     const { evDeploymentLocation, evModelYear, iceReplacementVehicle } =
       eere.inputs;
 
-    const monthlyEmissionRates = calculateMonthlyEmissionRates({
-      selectedRegionsStatesVMTPercentages,
-      evDeploymentLocation,
-      evModelYear,
-      iceReplacementVehicle,
-    });
+    const selectedRegionsMonthlyEmissionRates =
+      calculateSelectedRegionsMonthlyEmissionRates({
+        selectedRegionsStatesVMTPercentages,
+        evDeploymentLocation,
+        evModelYear,
+        iceReplacementVehicle,
+      });
 
     dispatch({
-      type: 'transportation/SET_MONTHLY_EMISSION_RATES',
-      payload: { monthlyEmissionRates },
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EMISSION_RATES',
+      payload: { selectedRegionsMonthlyEmissionRates },
     });
 
-    // NOTE: `monthlyEmissionChanges` uses `monthlyEmissionRates`
+    // NOTE: `monthlyEmissionChanges` uses `selectedRegionsMonthlyEmissionRates`
     dispatch(setEmissionChanges());
   };
 }
@@ -856,7 +859,7 @@ export function setEmissionChanges(): AppThunk {
       vmtPerVehicleTypeByGeography,
       selectedRegionsMonthlyVMTPerVehicleType,
       vehiclesDisplaced,
-      monthlyEmissionRates,
+      selectedRegionsMonthlyEmissionRates,
     } = transportation;
 
     const { evDeploymentLocation } = eere.inputs;
@@ -864,7 +867,7 @@ export function setEmissionChanges(): AppThunk {
     const monthlyEmissionChanges = calculateMonthlyEmissionChanges({
       selectedRegionsMonthlyVMTPerVehicleType,
       vehiclesDisplaced,
-      monthlyEmissionRates,
+      selectedRegionsMonthlyEmissionRates,
     });
 
     const totalMonthlyEmissionChanges = calculateTotalMonthlyEmissionChanges(

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -20,7 +20,7 @@ import type {
   SelectedRegionsMonthlyEmissionRates,
   SelectedRegionsMonthlyEmissionChanges,
   SelectedRegionsTotalMonthlyEmissionChanges,
-  TotalYearlyEmissionChanges,
+  SelectedRegionsTotalYearlyEmissionChanges,
   VehicleEmissionChangesByGeography,
   VehicleSalesAndStock,
   SelectedRegionsEEREDefaultsAverages,
@@ -48,7 +48,7 @@ import {
   calculateSelectedRegionsMonthlyEmissionRates,
   calculateSelectedRegionsMonthlyEmissionChanges,
   calculateSelectedRegionsTotalMonthlyEmissionChanges,
-  calculateTotalYearlyEmissionChanges,
+  calculateSelectedRegionsTotalYearlyEmissionChanges,
   calculateVehicleEmissionChangesByGeography,
   calculateVehicleSalesAndStock,
   calculateSelectedRegionsEEREDefaultsAverages,
@@ -156,8 +156,10 @@ type Action =
       };
     }
   | {
-      type: 'transportation/SET_TOTAL_YEARLY_EMISSION_CHANGES';
-      payload: { totalYearlyEmissionChanges: TotalYearlyEmissionChanges };
+      type: 'transportation/SET_SELECTED_REGIONS_TOTAL_YEARLY_EMISSION_CHANGES';
+      payload: {
+        selectedRegionsTotalYearlyEmissionChanges: SelectedRegionsTotalYearlyEmissionChanges;
+      };
     }
   | {
       type: 'transportation/SET_VEHICLE_EMISSION_CHANGES_BY_GEOGRAPHY';
@@ -203,7 +205,7 @@ type State = {
   selectedRegionsMonthlyEmissionRates: SelectedRegionsMonthlyEmissionRates | {};
   selectedRegionsMonthlyEmissionChanges: SelectedRegionsMonthlyEmissionChanges | {}; // prettier-ignore
   selectedRegionsTotalMonthlyEmissionChanges: SelectedRegionsTotalMonthlyEmissionChanges | {}; // prettier-ignore
-  totalYearlyEmissionChanges: TotalYearlyEmissionChanges;
+  selectedRegionsTotalYearlyEmissionChanges: SelectedRegionsTotalYearlyEmissionChanges | {}; // prettier-ignore
   vehicleEmissionChangesByGeography: VehicleEmissionChangesByGeography | {};
   vehicleSalesAndStock: VehicleSalesAndStock;
   selectedRegionsEEREDefaultsAverages: SelectedRegionsEEREDefaultsAverages;
@@ -247,13 +249,7 @@ const initialState: State = {
   selectedRegionsMonthlyEmissionRates: {},
   selectedRegionsMonthlyEmissionChanges: {},
   selectedRegionsTotalMonthlyEmissionChanges: {},
-  totalYearlyEmissionChanges: {
-    cars: { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
-    trucks: { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
-    transitBuses: { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
-    schoolBuses: { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
-    total: { CO2: 0, NOX: 0, SO2: 0, PM25: 0, VOCs: 0, NH3: 0 },
-  },
+  selectedRegionsTotalYearlyEmissionChanges: {},
   vehicleEmissionChangesByGeography: {},
   vehicleSalesAndStock: {},
   selectedRegionsEEREDefaultsAverages: {},
@@ -440,12 +436,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_TOTAL_YEARLY_EMISSION_CHANGES': {
-      const { totalYearlyEmissionChanges } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_TOTAL_YEARLY_EMISSION_CHANGES': {
+      const { selectedRegionsTotalYearlyEmissionChanges } = action.payload;
 
       return {
         ...state,
-        totalYearlyEmissionChanges,
+        selectedRegionsTotalYearlyEmissionChanges,
       };
     }
 
@@ -880,9 +876,10 @@ export function setEmissionChanges(): AppThunk {
         selectedRegionsMonthlyEmissionChanges,
       });
 
-    const totalYearlyEmissionChanges = calculateTotalYearlyEmissionChanges({
-      selectedRegionsTotalMonthlyEmissionChanges,
-    });
+    const selectedRegionsTotalYearlyEmissionChanges =
+      calculateSelectedRegionsTotalYearlyEmissionChanges({
+        selectedRegionsTotalMonthlyEmissionChanges,
+      });
 
     const geographicFocus = geography.focus;
 
@@ -904,7 +901,7 @@ export function setEmissionChanges(): AppThunk {
         countiesByGeography,
         selectedGeographyRegionIds,
         vmtPerVehicleTypeByGeography,
-        totalYearlyEmissionChanges,
+        selectedRegionsTotalYearlyEmissionChanges,
         evDeploymentLocation,
       });
 
@@ -919,8 +916,8 @@ export function setEmissionChanges(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_TOTAL_YEARLY_EMISSION_CHANGES',
-      payload: { totalYearlyEmissionChanges },
+      type: 'transportation/SET_SELECTED_REGIONS_TOTAL_YEARLY_EMISSION_CHANGES',
+      payload: { selectedRegionsTotalYearlyEmissionChanges },
     });
 
     dispatch({

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -7,7 +7,7 @@ import type {
   HourlyEVChargingPercentages,
   SelectedRegionsStatesVMTPercentages,
   SelectedRegionsVMTPercentagesPerVehicleType,
-  SelectedGeographyAverageVMTPerYear,
+  SelectedRegionsAverageVMTPerYear,
   MonthlyVMTPerVehicleType,
   EVEfficiencyPerVehicleType,
   DailyStats,
@@ -35,7 +35,7 @@ import {
   calculateHourlyEVChargingPercentages,
   calculateSelectedRegionsStatesVMTPercentages,
   calculateSelectedRegionsVMTPercentagesPerVehicleType,
-  calculateSelectedGeographyAverageVMTPerYear,
+  calculateSelectedRegionsAverageVMTPerYear,
   calculateMonthlyVMTPerVehicleType,
   calculateEVEfficiencyPerVehicleType,
   calculateDailyStats,
@@ -94,9 +94,9 @@ type Action =
       };
     }
   | {
-      type: 'transportation/SET_SELECTED_GEOGRAPHY_AVERAGE_VMT_PER_YEAR';
+      type: 'transportation/SET_SELECTED_REGIONS_AVERAGE_VMT_PER_YEAR';
       payload: {
-        selectedGeographyAverageVMTPerYear: SelectedGeographyAverageVMTPerYear;
+        selectedRegionsAverageVMTPerYear: SelectedRegionsAverageVMTPerYear;
       };
     }
   | {
@@ -182,7 +182,7 @@ type State = {
   hourlyEVChargingPercentages: HourlyEVChargingPercentages;
   selectedRegionsStatesVMTPercentages: SelectedRegionsStatesVMTPercentages | {};
   selectedRegionsVMTPercentagesPerVehicleType: SelectedRegionsVMTPercentagesPerVehicleType | {}; // prettier-ignore
-  selectedGeographyAverageVMTPerYear: SelectedGeographyAverageVMTPerYear;
+  selectedRegionsAverageVMTPerYear: SelectedRegionsAverageVMTPerYear | {};
   monthlyVMTPerVehicleType: MonthlyVMTPerVehicleType;
   evEfficiencyPerVehicleType: EVEfficiencyPerVehicleType;
   dailyStats: DailyStats;
@@ -210,12 +210,7 @@ const initialState: State = {
   hourlyEVChargingPercentages: {},
   selectedRegionsStatesVMTPercentages: {},
   selectedRegionsVMTPercentagesPerVehicleType: {},
-  selectedGeographyAverageVMTPerYear: {
-    cars: 0,
-    trucks: 0,
-    transitBuses: 0,
-    schoolBuses: 0,
-  },
+  selectedRegionsAverageVMTPerYear: {},
   monthlyVMTPerVehicleType: {},
   evEfficiencyPerVehicleType: {
     batteryEVCars: 0,
@@ -329,12 +324,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_SELECTED_GEOGRAPHY_AVERAGE_VMT_PER_YEAR': {
-      const { selectedGeographyAverageVMTPerYear } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_AVERAGE_VMT_PER_YEAR': {
+      const { selectedRegionsAverageVMTPerYear } = action.payload;
 
       return {
         ...state,
-        selectedGeographyAverageVMTPerYear,
+        selectedRegionsAverageVMTPerYear,
       };
     }
 
@@ -589,13 +584,13 @@ export function setSelectedGeographyVMTData(): AppThunk {
         vmtAllocationPerVehicle,
       });
 
-    const selectedGeographyAverageVMTPerYear =
-      calculateSelectedGeographyAverageVMTPerYear(
+    const selectedRegionsAverageVMTPerYear =
+      calculateSelectedRegionsAverageVMTPerYear({
         selectedRegionsVMTPercentagesPerVehicleType,
-      );
+      });
 
     const monthlyVMTPerVehicleType = calculateMonthlyVMTPerVehicleType({
-      selectedGeographyAverageVMTPerYear,
+      selectedRegionsAverageVMTPerYear,
       monthlyVMTTotalsAndPercentages,
     });
 
@@ -610,8 +605,8 @@ export function setSelectedGeographyVMTData(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_SELECTED_GEOGRAPHY_AVERAGE_VMT_PER_YEAR',
-      payload: { selectedGeographyAverageVMTPerYear },
+      type: 'transportation/SET_SELECTED_REGIONS_AVERAGE_VMT_PER_YEAR',
+      payload: { selectedRegionsAverageVMTPerYear },
     });
 
     dispatch({

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -5,7 +5,7 @@ import type {
   VMTAllocationPerVehicle,
   MonthlyVMTTotalsAndPercentages,
   HourlyEVChargingPercentages,
-  SelectedGeographyStatesVMTPercentages,
+  SelectedRegionsStatesVMTPercentages,
   SelectedGeographyVMTPercentagesPerVehicleType,
   SelectedGeographyAverageVMTPerYear,
   MonthlyVMTPerVehicleType,
@@ -33,7 +33,7 @@ import {
   calculateVMTAllocationPerVehicle,
   calculateMonthlyVMTTotalsAndPercentages,
   calculateHourlyEVChargingPercentages,
-  calculateSelectedGeographyStatesVMTPercentages,
+  calculateSelectedRegionsStatesVMTPercentages,
   calculateSelectedGeographyVMTPercentagesPerVehicleType,
   calculateSelectedGeographyAverageVMTPerYear,
   calculateMonthlyVMTPerVehicleType,
@@ -82,9 +82,9 @@ type TransportationAction =
       payload: { hourlyEVChargingPercentages: HourlyEVChargingPercentages };
     }
   | {
-      type: 'transportation/SET_SELECTED_GEOGRAPHY_STATES_VMT_PERCENTAGES';
+      type: 'transportation/SET_SELECTED_REGIONS_STATES_VMT_PERCENTAGES';
       payload: {
-        selectedGeographyStatesVMTPercentages: SelectedGeographyStatesVMTPercentages;
+        selectedRegionsStatesVMTPercentages: SelectedRegionsStatesVMTPercentages;
       };
     }
   | {
@@ -180,7 +180,7 @@ type TransportationState = {
   vmtAllocationPerVehicle: VMTAllocationPerVehicle | {};
   monthlyVMTTotalsAndPercentages: MonthlyVMTTotalsAndPercentages;
   hourlyEVChargingPercentages: HourlyEVChargingPercentages;
-  selectedGeographyStatesVMTPercentages: SelectedGeographyStatesVMTPercentages | {}; // prettier-ignore
+  selectedRegionsStatesVMTPercentages: SelectedRegionsStatesVMTPercentages | {};
   selectedGeographyVMTPercentagesPerVehicleType: SelectedGeographyVMTPercentagesPerVehicleType;
   selectedGeographyAverageVMTPerYear: SelectedGeographyAverageVMTPerYear;
   monthlyVMTPerVehicleType: MonthlyVMTPerVehicleType;
@@ -208,7 +208,7 @@ const initialState: TransportationState = {
   vmtAllocationPerVehicle: {},
   monthlyVMTTotalsAndPercentages: {},
   hourlyEVChargingPercentages: {},
-  selectedGeographyStatesVMTPercentages: {},
+  selectedRegionsStatesVMTPercentages: {},
   selectedGeographyVMTPercentagesPerVehicleType: {
     vmtPerLDVPercent: 0,
     vmtPerBusPercent: 0,
@@ -314,12 +314,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_SELECTED_GEOGRAPHY_STATES_VMT_PERCENTAGES': {
-      const { selectedGeographyStatesVMTPercentages } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_STATES_VMT_PERCENTAGES': {
+      const { selectedRegionsStatesVMTPercentages } = action.payload;
 
       return {
         ...state,
-        selectedGeographyStatesVMTPercentages,
+        selectedRegionsStatesVMTPercentages,
       };
     }
 
@@ -578,8 +578,8 @@ export function setSelectedGeographyVMTData(): AppThunk {
     const selectedStateId =
       Object.values(geography.states).find((s) => s.selected)?.id || '';
 
-    const selectedGeographyStatesVMTPercentages =
-      calculateSelectedGeographyStatesVMTPercentages({
+    const selectedRegionsStatesVMTPercentages =
+      calculateSelectedRegionsStatesVMTPercentages({
         geographicFocus,
         selectedRegionId,
         selectedStateId,
@@ -588,7 +588,7 @@ export function setSelectedGeographyVMTData(): AppThunk {
 
     const selectedGeographyVMTPercentagesPerVehicleType =
       calculateSelectedGeographyVMTPercentagesPerVehicleType({
-        selectedGeographyStatesVMTPercentages,
+        selectedRegionsStatesVMTPercentages,
         vmtAllocationPerVehicle,
       });
 
@@ -603,8 +603,8 @@ export function setSelectedGeographyVMTData(): AppThunk {
     });
 
     dispatch({
-      type: 'transportation/SET_SELECTED_GEOGRAPHY_STATES_VMT_PERCENTAGES',
-      payload: { selectedGeographyStatesVMTPercentages },
+      type: 'transportation/SET_SELECTED_REGIONS_STATES_VMT_PERCENTAGES',
+      payload: { selectedRegionsStatesVMTPercentages },
     });
 
     dispatch({
@@ -824,12 +824,12 @@ export function setMonthlyDailyEVEnergyUsage(): AppThunk {
 export function setMonthlyEmissionRates(): AppThunk {
   return (dispatch, getState) => {
     const { transportation, eere } = getState();
-    const { selectedGeographyStatesVMTPercentages } = transportation;
+    const { selectedRegionsStatesVMTPercentages } = transportation;
     const { evDeploymentLocation, evModelYear, iceReplacementVehicle } =
       eere.inputs;
 
     const monthlyEmissionRates = calculateMonthlyEmissionRates({
-      selectedGeographyStatesVMTPercentages,
+      selectedRegionsStatesVMTPercentages,
       evDeploymentLocation,
       evModelYear,
       iceReplacementVehicle,

--- a/client/src/app/redux/reducers/transportation.ts
+++ b/client/src/app/redux/reducers/transportation.ts
@@ -16,7 +16,7 @@ import type {
   SelectedRegionsMonthlyEVEnergyUsageGW,
   SelectedRegionsMonthlyEVEnergyUsageMW,
   SelectedRegionsTotalYearlyEVEnergyUsage,
-  MonthlyDailyEVEnergyUsage,
+  SelectedRegionsMonthlyDailyEVEnergyUsage,
   SelectedRegionsMonthlyEmissionRates,
   SelectedRegionsMonthlyEmissionChanges,
   SelectedRegionsTotalMonthlyEmissionChanges,
@@ -44,7 +44,7 @@ import {
   calculateSelectedRegionsMonthlyEVEnergyUsageGW,
   calculateSelectedRegionsMonthlyEVEnergyUsageMW,
   calculateSelectedRegionsTotalYearlyEVEnergyUsage,
-  calculateMonthlyDailyEVEnergyUsage,
+  calculateSelectedRegionsMonthlyDailyEVEnergyUsage,
   calculateSelectedRegionsMonthlyEmissionRates,
   calculateSelectedRegionsMonthlyEmissionChanges,
   calculateSelectedRegionsTotalMonthlyEmissionChanges,
@@ -140,8 +140,10 @@ type Action =
       };
     }
   | {
-      type: 'transportation/SET_MONTHLY_DAILY_EV_ENERGY_USAGE';
-      payload: { monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage };
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_DAILY_EV_ENERGY_USAGE';
+      payload: {
+        selectedRegionsMonthlyDailyEVEnergyUsage: SelectedRegionsMonthlyDailyEVEnergyUsage;
+      };
     }
   | {
       type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_EMISSION_RATES';
@@ -207,7 +209,7 @@ type State = {
   selectedRegionsMonthlyEVEnergyUsageGW: SelectedRegionsMonthlyEVEnergyUsageGW | {}; // prettier-ignore
   selectedRegionsMonthlyEVEnergyUsageMW: SelectedRegionsMonthlyEVEnergyUsageMW | {}; // prettier-ignore
   selectedRegionsTotalYearlyEVEnergyUsage: SelectedRegionsTotalYearlyEVEnergyUsage | {}; // prettier-ignore
-  monthlyDailyEVEnergyUsage: MonthlyDailyEVEnergyUsage;
+  selectedRegionsMonthlyDailyEVEnergyUsage: SelectedRegionsMonthlyDailyEVEnergyUsage | {}; // prettier-ignore
   selectedRegionsMonthlyEmissionRates: SelectedRegionsMonthlyEmissionRates | {};
   selectedRegionsMonthlyEmissionChanges: SelectedRegionsMonthlyEmissionChanges | {}; // prettier-ignore
   selectedRegionsTotalMonthlyEmissionChanges: SelectedRegionsTotalMonthlyEmissionChanges | {}; // prettier-ignore
@@ -251,7 +253,7 @@ const initialState: State = {
   selectedRegionsMonthlyEVEnergyUsageGW: {},
   selectedRegionsMonthlyEVEnergyUsageMW: {},
   selectedRegionsTotalYearlyEVEnergyUsage: {},
-  monthlyDailyEVEnergyUsage: {},
+  selectedRegionsMonthlyDailyEVEnergyUsage: {},
   selectedRegionsMonthlyEmissionRates: {},
   selectedRegionsMonthlyEmissionChanges: {},
   selectedRegionsTotalMonthlyEmissionChanges: {},
@@ -406,12 +408,12 @@ export default function reducer(
       };
     }
 
-    case 'transportation/SET_MONTHLY_DAILY_EV_ENERGY_USAGE': {
-      const { monthlyDailyEVEnergyUsage } = action.payload;
+    case 'transportation/SET_SELECTED_REGIONS_MONTHLY_DAILY_EV_ENERGY_USAGE': {
+      const { selectedRegionsMonthlyDailyEVEnergyUsage } = action.payload;
 
       return {
         ...state,
-        monthlyDailyEVEnergyUsage,
+        selectedRegionsMonthlyDailyEVEnergyUsage,
       };
     }
 
@@ -696,7 +698,7 @@ export function setDailyAndMonthlyStats(): AppThunk {
       payload: { monthlyStats },
     });
 
-    // NOTE: `monthlyDailyEVEnergyUsage` uses `monthlyStats`
+    // NOTE: `selectedRegionsMonthlyDailyEVEnergyUsage` uses `monthlyStats`
     dispatch(setMonthlyDailyEVEnergyUsage());
   };
 }
@@ -785,7 +787,7 @@ export function setMonthlyEVEnergyUsage(): AppThunk {
       payload: { selectedRegionsTotalYearlyEVEnergyUsage },
     });
 
-    // NOTE: `monthlyDailyEVEnergyUsage` uses `selectedRegionsMonthlyEVEnergyUsageMW`
+    // NOTE: `selectedRegionsMonthlyDailyEVEnergyUsage` uses `selectedRegionsMonthlyEVEnergyUsageMW`
     dispatch(setMonthlyDailyEVEnergyUsage());
   };
 }
@@ -807,14 +809,17 @@ export function setMonthlyDailyEVEnergyUsage(): AppThunk {
     const { monthlyStats, selectedRegionsMonthlyEVEnergyUsageMW } =
       transportation;
 
-    const monthlyDailyEVEnergyUsage = calculateMonthlyDailyEVEnergyUsage({
-      selectedRegionsMonthlyEVEnergyUsageMW,
-      monthlyStats,
-    });
+    const selectedRegionsMonthlyDailyEVEnergyUsage =
+      calculateSelectedRegionsMonthlyDailyEVEnergyUsage({
+        selectedRegionsMonthlyEVEnergyUsageMW,
+        monthlyStats,
+      });
+
+    console.log(selectedRegionsMonthlyDailyEVEnergyUsage);
 
     dispatch({
-      type: 'transportation/SET_MONTHLY_DAILY_EV_ENERGY_USAGE',
-      payload: { monthlyDailyEVEnergyUsage },
+      type: 'transportation/SET_SELECTED_REGIONS_MONTHLY_DAILY_EV_ENERGY_USAGE',
+      payload: { selectedRegionsMonthlyDailyEVEnergyUsage },
     });
   };
 }


### PR DESCRIPTION
Update transportation calculations to store data at the regional level, so we have access to monthly emission changes data for vehicles at the region level to display in charts on the results screen (ends up being no change if a region was selected on the select geography screen, but now if a state is selected, we have monthly vehicle data for each affected region, not just the aggregated affected regions, like we did before).