### PR TITLE
Feature/update ev tables

### DIFF
--- a/client/src/app/components/EVTables.tsx
+++ b/client/src/app/components/EVTables.tsx
@@ -173,7 +173,7 @@ function EEREEVComparisonTableContent(props: { className?: string }) {
       : null;
 
   const totalYearlyEVEnergyUsage = selectedRegionsEnergyData
-    ? Object.values(selectedRegionsEnergyData).reduce((a, b) => a + b, 0)
+    ? Object.values(selectedRegionsEnergyData).reduce((a, b) => (a || 0) + (b || 0), 0) // prettier-ignore
     : 0;
 
   const historicalEERetailMw = evDeploymentLocationHistoricalEERE.eeRetail.mw;


### PR DESCRIPTION
Update setting of `totalYearlyEVEnergyUsage` in `EEREEVComparisonTableContent` to account for when a region's total yearly EV energy usage is null (due to an invalid character being entered into an EV input).

Now if an non-number character is entered into an EV input, the "EERE Required..." columns of the EE/RE and EV Comparison table will show those numbers as `0` instead of `NaN`.