### PR TITLE
Feature/apply review changes

### DIFF
--- a/client/src/app/components/ImpactsInputs.tsx
+++ b/client/src/app/components/ImpactsInputs.tsx
@@ -14,7 +14,10 @@ import {
 import { Tooltip } from 'app/components/Tooltip';
 import { useTypedSelector } from 'app/redux/index';
 import { displayModalDialog } from 'app/redux/reducers/panel';
-import { RegionState } from 'app/redux/reducers/geography';
+import type {
+  GeographicFocus,
+  RegionState,
+} from 'app/redux/reducers/geography';
 import {
   updateEEAnnualGwh,
   updateEEConstantMw,
@@ -84,13 +87,20 @@ const inputsSummaryStyles = css`
  * warning modal dialog.
  */
 function checkTransitBusesWarningScenario(options: {
+  geographicFocus: GeographicFocus;
   selectedRegion: RegionState | undefined;
   evDeploymentLocation: string;
   transitBuses: string;
 }) {
-  const { selectedRegion, evDeploymentLocation, transitBuses } = options;
+  const {
+    geographicFocus,
+    selectedRegion,
+    evDeploymentLocation,
+    transitBuses,
+  } = options;
 
   return (
+    geographicFocus === 'regions' &&
     selectedRegion?.id === 'RM' &&
     ['state-MT', 'state-UT'].includes(evDeploymentLocation) &&
     transitBuses !== '' &&
@@ -758,6 +768,7 @@ function ImpactsInputsContent() {
 
                               if (
                                 checkTransitBusesWarningScenario({
+                                  geographicFocus,
                                   selectedRegion,
                                   evDeploymentLocation,
                                   transitBuses: value,
@@ -825,6 +836,7 @@ function ImpactsInputsContent() {
 
                           if (
                             checkTransitBusesWarningScenario({
+                              geographicFocus,
                               selectedRegion,
                               evDeploymentLocation: option,
                               transitBuses,

--- a/client/src/app/components/PowerEmissionsTable.tsx
+++ b/client/src/app/components/PowerEmissionsTable.tsx
@@ -587,8 +587,8 @@ function PowerEmissionsTableContent() {
           emissions from tailpipes).
         </li>
         <li>
-          Estimated marginal CO2 emission rates for future years are available
-          in the current{' '}
+          Estimated marginal CO<sub>2</sub> emission rates for future years are
+          available in the current{' '}
           <a
             className="usa-link"
             href="https://www.epa.gov/avert/download-avert"


### PR DESCRIPTION
Update logic in determining if the transit buses warning dialog is shown to be limited to if a region is selected, and subscript the 2 in CO2 in the footnote below the power emissions table.