### PR TITLE
Feature/update cobra index

### DIFF
--- a/client/cobra/index.html
+++ b/client/cobra/index.html
@@ -14,6 +14,13 @@
       media="all"
       href="https://www.epa.gov/themes/epa_theme/css/styles.css"
     />
+    <style>
+      :root {
+        --avert-blue: rgb(0, 128, 164);
+        --avert-dark-blue: rgb(0, 108, 150);
+        --avert-light-blue: rgb(0, 164, 200);
+      }
+    </style>
   </head>
 
   <body class="margin-top-2 margin-x-auto maxw-tablet">


### PR DESCRIPTION
Small follow-up to #147 – Add missing `--avert-blue` css custom property to cobra `index.html`. When moving the AVERT app styles out of the `src/styles.css` directory, I forgot the `COBRAPendingMessage` component's dots use the `--avert-blue` css custom property. The other two related CSS custom properties aren't used here, but I included them all as a group in case the `COBRAPendingMessage` component eventually were to use more of the branded AVERT colors.