### PR TITLE
Feature/update selected state vehicle calculations

### DIFF
--- a/client/src/calculations/transportation.ts
+++ b/client/src/calculations/transportation.ts
@@ -221,6 +221,7 @@ export type VMTTotalsByStateRegionCombo = ReturnType<
   typeof calculateVMTTotalsByStateRegionCombo
 >;
 export type VMTTotalsByRegion = ReturnType<typeof calculateVMTTotalsByRegion>;
+export type VMTTotalsByState = ReturnType<typeof calculateVMTTotalsByState>;
 export type VMTPercentagesByStateRegionCombo = ReturnType<
   typeof calculateVMTPercentagesByStateRegionCombo
 >;
@@ -929,6 +930,62 @@ export function calculateVMTTotalsByRegion(options: {
     },
     {} as {
       [region in RegionName]: {
+        [vehicle in VehicleType]: number;
+      };
+    },
+  );
+
+  return result;
+}
+
+/**
+ * Total vehicle miles traveled (VMT) in billions by state for each vehicle
+ * type.
+ *
+ * NOTE: not in Excel file, but follows the same structure as the bottom left
+ * table in the "RegionStateAllocate" sheet (B87:R100), only for each state
+ * instead of each AVERT region.
+ */
+export function calculateVMTTotalsByState(options: {
+  vmtTotalsByStateRegionCombo: VMTTotalsByStateRegionCombo;
+}) {
+  const { vmtTotalsByStateRegionCombo } = options;
+
+  const result = Object.values(vmtTotalsByStateRegionCombo).reduce(
+    (object, data) => {
+      const state = data.state as StateId;
+
+      if (!object[state]) {
+        object[state] = {
+          "Passenger cars": 0,
+          "Passenger trucks": 0,
+          "Medium-duty transit buses": 0,
+          "Heavy-duty transit buses": 0,
+          "Medium-duty school buses": 0,
+          "Heavy-duty school buses": 0,
+          "Medium-duty other buses": 0,
+          "Heavy-duty other buses": 0,
+          "Light-duty single unit trucks": 0,
+          "Medium-duty single unit trucks": 0,
+          "Heavy-duty combination trucks": 0,
+          "Combination long-haul trucks": 0,
+          "Medium-duty refuse trucks": 0,
+          "Heavy-duty refuse trucks": 0,
+        };
+      }
+
+      Object.entries(data.vehicleTypes).forEach(([vmtKey, vmtValue]) => {
+        const vehicle = vmtKey as keyof typeof data.vehicleTypes;
+
+        if (vehicle in object[state]) {
+          object[state][vehicle] += vmtValue;
+        }
+      });
+
+      return object;
+    },
+    {} as {
+      [state in StateId]: {
         [vehicle in VehicleType]: number;
       };
     },

--- a/client/src/calculations/transportation.ts
+++ b/client/src/calculations/transportation.ts
@@ -238,15 +238,15 @@ export type VehicleTypePercentagesOfVehicleCategory = ReturnType<
 export type VehicleFuelTypePercentagesOfVehicleType = ReturnType<
   typeof calculateVehicleFuelTypePercentagesOfVehicleType
 >;
-export type SelectedRegionsTotalEffectiveVehicles = ReturnType<
-  typeof calculateSelectedRegionsTotalEffectiveVehicles
->;
 export type VMTandStockByState = ReturnType<typeof storeVMTandStockByState>;
 export type LDVsFhwaMovesVMTRatioByState = ReturnType<
   typeof calculateLDVsFhwaMovesVMTRatioByState
 >;
 export type VMTPerVehicleTypeByState = ReturnType<
   typeof calculateVMTPerVehicleTypeByState
+>;
+export type SelectedRegionsTotalEffectiveVehicles = ReturnType<
+  typeof calculateSelectedRegionsTotalEffectiveVehicles
 >;
 export type SelectedRegionsVMTPercentagesByState = ReturnType<
   typeof calculateSelectedRegionsVMTPercentagesByState
@@ -1382,131 +1382,6 @@ export function calculateVehicleFuelTypePercentagesOfVehicleType(options: {
 }
 
 /**
- * Selected AVERT region's total number of effective vehicles by vehicle
- * category / vehicle type / fuel type combo.
- *
- * Excel: "Sales Changes" data from "Table 8: Calculated changes for the
- * transportation sector" table in the "Library" sheet (E546:E567).
- */
-export function calculateSelectedRegionsTotalEffectiveVehicles(options: {
-  selectedGeographyRegionIds: RegionId[];
-  vehicleTypePercentagesOfVehicleCategory:
-    | VehicleTypePercentagesOfVehicleCategory
-    | EmptyObject;
-  vehicleFuelTypePercentagesOfVehicleType:
-    | VehicleFuelTypePercentagesOfVehicleType
-    | EmptyObject;
-  batteryEVs: number;
-  hybridEVs: number;
-  transitBuses: number;
-  schoolBuses: number;
-  shortHaulTrucks: number;
-  comboLongHaulTrucks: number;
-  refuseTrucks: number;
-}) {
-  const {
-    selectedGeographyRegionIds,
-    vehicleTypePercentagesOfVehicleCategory,
-    vehicleFuelTypePercentagesOfVehicleType,
-    batteryEVs,
-    hybridEVs,
-    transitBuses,
-    schoolBuses,
-    shortHaulTrucks,
-    comboLongHaulTrucks,
-    refuseTrucks,
-  } = options;
-
-  if (
-    selectedGeographyRegionIds.length === 0 ||
-    Object.keys(vehicleTypePercentagesOfVehicleCategory).length === 0 ||
-    Object.keys(vehicleFuelTypePercentagesOfVehicleType).length === 0
-  ) {
-    return {} as {
-      [regionId in RegionId]: {
-        [categoryVehicleFuelCombo in VehicleCategoryVehicleTypeFuelTypeCombo]: number;
-      };
-    };
-  }
-
-  const result = selectedGeographyRegionIds.reduce(
-    (object, regionId) => {
-      object[regionId] ??= {
-        "Battery EVs / Passenger cars / Gasoline": 0,
-        "Plug-in Hybrid EVs / Passenger cars / Gasoline": 0,
-        "Battery EVs / Passenger trucks / Gasoline": 0,
-        "Plug-in Hybrid EVs / Passenger trucks / Gasoline": 0,
-        "Transit buses / Medium-duty transit buses / Gasoline": 0,
-        "Transit buses / Medium-duty transit buses / Diesel Fuel": 0,
-        "Transit buses / Heavy-duty transit buses / Diesel Fuel": 0,
-        "Transit buses / Heavy-duty transit buses / Compressed Natural Gas (CNG)": 0,
-        "School buses / Medium-duty school buses / Gasoline": 0,
-        "School buses / Medium-duty school buses / Diesel Fuel": 0,
-        "School buses / Heavy-duty school buses / Diesel Fuel": 0,
-        "Other buses / Medium-duty other buses / Gasoline": 0,
-        "Other buses / Medium-duty other buses / Diesel Fuel": 0,
-        "Other buses / Heavy-duty other buses / Diesel Fuel": 0,
-        "Other buses / Heavy-duty other buses / Compressed Natural Gas (CNG)": 0,
-        "Short-haul trucks / Light-duty single unit trucks / Gasoline": 0,
-        "Short-haul trucks / Medium-duty single unit trucks / Gasoline": 0,
-        "Short-haul trucks / Medium-duty single unit trucks / Diesel Fuel": 0,
-        "Short-haul trucks / Heavy-duty combination trucks / Diesel Fuel": 0,
-        "Long-haul trucks / Combination long-haul trucks / Diesel Fuel": 0,
-        "Refuse trucks / Medium-duty refuse trucks / Diesel Fuel": 0,
-        "Refuse trucks / Heavy-duty refuse trucks / Diesel Fuel": 0,
-      };
-
-      Object.keys(object[regionId]).forEach((key) => {
-        const categoryVehicleFuelCombo = key as keyof typeof object[typeof regionId]; // prettier-ignore
-
-        const [vehicleCategory, vehicleType, fuelType] = key.split(" / ");
-
-        const vehicleInputValue =
-          vehicleCategory === "Battery EVs"
-            ? batteryEVs
-            : vehicleCategory === "Plug-in Hybrid EVs"
-              ? hybridEVs
-              : vehicleCategory === "Transit buses"
-                ? transitBuses
-                : vehicleCategory === "School buses"
-                  ? schoolBuses
-                  : vehicleCategory === "Short-haul trucks"
-                    ? shortHaulTrucks
-                    : vehicleCategory === "Long-haul trucks"
-                      ? comboLongHaulTrucks
-                      : vehicleCategory === "Refuse trucks"
-                        ? refuseTrucks
-                        : 0;
-
-        const categoryVehicleCombo =
-          `${vehicleCategory} / ${vehicleType}` as VehicleCategoryVehicleTypeCombo;
-
-        const vehicleFuelCombo =
-          `${vehicleType} / ${fuelType}` as VehicleTypeFuelTypeCombo;
-
-        const vehicleTypePercentage =
-          vehicleTypePercentagesOfVehicleCategory?.[categoryVehicleCombo] || 0;
-
-        const vehicleFuelPercengage =
-          vehicleFuelTypePercentagesOfVehicleType?.[vehicleFuelCombo] || 0;
-
-        object[regionId][categoryVehicleFuelCombo] =
-          vehicleInputValue * vehicleTypePercentage * vehicleFuelPercengage;
-      });
-
-      return object;
-    },
-    {} as {
-      [regionId in RegionId]: {
-        [categoryVehicleFuelCombo in VehicleCategoryVehicleTypeFuelTypeCombo]: number;
-      };
-    },
-  );
-
-  return result;
-}
-
-/**
  * Stores 2023 annual vehicle miles traveled (VMT) and 2023 stock (both in
  * millions) by state for each vehicle type.
  *
@@ -1649,6 +1524,131 @@ export function calculateVMTPerVehicleTypeByState(options: {
           vmtPerVehicle: number;
           vmtPerVehicleAdjustedByFHWA: number;
         };
+      };
+    },
+  );
+
+  return result;
+}
+
+/**
+ * Selected AVERT region's total number of effective vehicles by vehicle
+ * category / vehicle type / fuel type combo.
+ *
+ * Excel: "Sales Changes" data from "Table 8: Calculated changes for the
+ * transportation sector" table in the "Library" sheet (E546:E567).
+ */
+export function calculateSelectedRegionsTotalEffectiveVehicles(options: {
+  selectedGeographyRegionIds: RegionId[];
+  vehicleTypePercentagesOfVehicleCategory:
+    | VehicleTypePercentagesOfVehicleCategory
+    | EmptyObject;
+  vehicleFuelTypePercentagesOfVehicleType:
+    | VehicleFuelTypePercentagesOfVehicleType
+    | EmptyObject;
+  batteryEVs: number;
+  hybridEVs: number;
+  transitBuses: number;
+  schoolBuses: number;
+  shortHaulTrucks: number;
+  comboLongHaulTrucks: number;
+  refuseTrucks: number;
+}) {
+  const {
+    selectedGeographyRegionIds,
+    vehicleTypePercentagesOfVehicleCategory,
+    vehicleFuelTypePercentagesOfVehicleType,
+    batteryEVs,
+    hybridEVs,
+    transitBuses,
+    schoolBuses,
+    shortHaulTrucks,
+    comboLongHaulTrucks,
+    refuseTrucks,
+  } = options;
+
+  if (
+    selectedGeographyRegionIds.length === 0 ||
+    Object.keys(vehicleTypePercentagesOfVehicleCategory).length === 0 ||
+    Object.keys(vehicleFuelTypePercentagesOfVehicleType).length === 0
+  ) {
+    return {} as {
+      [regionId in RegionId]: {
+        [categoryVehicleFuelCombo in VehicleCategoryVehicleTypeFuelTypeCombo]: number;
+      };
+    };
+  }
+
+  const result = selectedGeographyRegionIds.reduce(
+    (object, regionId) => {
+      object[regionId] ??= {
+        "Battery EVs / Passenger cars / Gasoline": 0,
+        "Plug-in Hybrid EVs / Passenger cars / Gasoline": 0,
+        "Battery EVs / Passenger trucks / Gasoline": 0,
+        "Plug-in Hybrid EVs / Passenger trucks / Gasoline": 0,
+        "Transit buses / Medium-duty transit buses / Gasoline": 0,
+        "Transit buses / Medium-duty transit buses / Diesel Fuel": 0,
+        "Transit buses / Heavy-duty transit buses / Diesel Fuel": 0,
+        "Transit buses / Heavy-duty transit buses / Compressed Natural Gas (CNG)": 0,
+        "School buses / Medium-duty school buses / Gasoline": 0,
+        "School buses / Medium-duty school buses / Diesel Fuel": 0,
+        "School buses / Heavy-duty school buses / Diesel Fuel": 0,
+        "Other buses / Medium-duty other buses / Gasoline": 0,
+        "Other buses / Medium-duty other buses / Diesel Fuel": 0,
+        "Other buses / Heavy-duty other buses / Diesel Fuel": 0,
+        "Other buses / Heavy-duty other buses / Compressed Natural Gas (CNG)": 0,
+        "Short-haul trucks / Light-duty single unit trucks / Gasoline": 0,
+        "Short-haul trucks / Medium-duty single unit trucks / Gasoline": 0,
+        "Short-haul trucks / Medium-duty single unit trucks / Diesel Fuel": 0,
+        "Short-haul trucks / Heavy-duty combination trucks / Diesel Fuel": 0,
+        "Long-haul trucks / Combination long-haul trucks / Diesel Fuel": 0,
+        "Refuse trucks / Medium-duty refuse trucks / Diesel Fuel": 0,
+        "Refuse trucks / Heavy-duty refuse trucks / Diesel Fuel": 0,
+      };
+
+      Object.keys(object[regionId]).forEach((key) => {
+        const categoryVehicleFuelCombo = key as keyof typeof object[typeof regionId]; // prettier-ignore
+
+        const [vehicleCategory, vehicleType, fuelType] = key.split(" / ");
+
+        const vehicleInputValue =
+          vehicleCategory === "Battery EVs"
+            ? batteryEVs
+            : vehicleCategory === "Plug-in Hybrid EVs"
+              ? hybridEVs
+              : vehicleCategory === "Transit buses"
+                ? transitBuses
+                : vehicleCategory === "School buses"
+                  ? schoolBuses
+                  : vehicleCategory === "Short-haul trucks"
+                    ? shortHaulTrucks
+                    : vehicleCategory === "Long-haul trucks"
+                      ? comboLongHaulTrucks
+                      : vehicleCategory === "Refuse trucks"
+                        ? refuseTrucks
+                        : 0;
+
+        const categoryVehicleCombo =
+          `${vehicleCategory} / ${vehicleType}` as VehicleCategoryVehicleTypeCombo;
+
+        const vehicleFuelCombo =
+          `${vehicleType} / ${fuelType}` as VehicleTypeFuelTypeCombo;
+
+        const vehicleTypePercentage =
+          vehicleTypePercentagesOfVehicleCategory?.[categoryVehicleCombo] || 0;
+
+        const vehicleFuelPercengage =
+          vehicleFuelTypePercentagesOfVehicleType?.[vehicleFuelCombo] || 0;
+
+        object[regionId][categoryVehicleFuelCombo] =
+          vehicleInputValue * vehicleTypePercentage * vehicleFuelPercengage;
+      });
+
+      return object;
+    },
+    {} as {
+      [regionId in RegionId]: {
+        [categoryVehicleFuelCombo in VehicleCategoryVehicleTypeFuelTypeCombo]: number;
       };
     },
   );

--- a/client/src/redux/reducers/geography.ts
+++ b/client/src/redux/reducers/geography.ts
@@ -13,6 +13,7 @@ import {
   setSelectedGeographyVMTData,
   setEVEfficiency,
   setDailyAndMonthlyStats,
+  setEffectiveVehicles,
   setSelectedRegionsEEREDefaultsAverages,
 } from "@/redux/reducers/transportation";
 import { type EmptyObject } from "@/utilities";
@@ -490,6 +491,7 @@ export function selectGeography(focus: GeographicFocus): AppThunk {
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
     dispatch(setEVEfficiency());
+    dispatch(setEffectiveVehicles());
   };
 }
 
@@ -508,6 +510,7 @@ export function selectRegion(regionId: RegionId): AppThunk {
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
     dispatch(setEVEfficiency());
+    dispatch(setEffectiveVehicles());
   };
 }
 
@@ -526,6 +529,7 @@ export function selectState(stateId: string): AppThunk {
     dispatch(setEVDeploymentLocationOptions());
     dispatch(setSelectedGeographyVMTData());
     dispatch(setEVEfficiency());
+    dispatch(setEffectiveVehicles());
   };
 }
 

--- a/client/src/redux/reducers/transportation.ts
+++ b/client/src/redux/reducers/transportation.ts
@@ -17,10 +17,10 @@ import {
   type VehicleCategoryTotals,
   type VehicleTypePercentagesOfVehicleCategory,
   type VehicleFuelTypePercentagesOfVehicleType,
-  type SelectedRegionsTotalEffectiveVehicles,
   type VMTandStockByState,
   type LDVsFhwaMovesVMTRatioByState,
   type VMTPerVehicleTypeByState,
+  type SelectedRegionsTotalEffectiveVehicles,
   type SelectedRegionsVMTPercentagesByState,
   type SelectedRegionsAverageVMTPerYear,
   type SelectedRegionsMonthlyVMT,
@@ -60,10 +60,10 @@ import {
   calculateVehicleCategoryTotals,
   calculateVehicleTypePercentagesOfVehicleCategory,
   calculateVehicleFuelTypePercentagesOfVehicleType,
-  calculateSelectedRegionsTotalEffectiveVehicles,
   storeVMTandStockByState,
   calculateLDVsFhwaMovesVMTRatioByState,
   calculateVMTPerVehicleTypeByState,
+  calculateSelectedRegionsTotalEffectiveVehicles,
   calculateSelectedRegionsVMTPercentagesByState,
   calculateSelectedRegionsAverageVMTPerYear,
   calculateSelectedRegionsMonthlyVMT,
@@ -239,12 +239,6 @@ type Action =
       };
     }
   | {
-      type: "transportation/SET_SELECTED_REGIONS_TOTAL_EFFECTIVE_VEHICLES";
-      payload: {
-        selectedRegionsTotalEffectiveVehicles: SelectedRegionsTotalEffectiveVehicles;
-      };
-    }
-  | {
       type: "transportation/SET_VMT_AND_STOCK_BY_STATE";
       payload: {
         vmtAndStockByState: VMTandStockByState;
@@ -260,6 +254,12 @@ type Action =
       type: "transportation/SET_VMT_PER_VEHICLE_TYPE_BY_STATE";
       payload: {
         vmtPerVehicleTypeByState: VMTPerVehicleTypeByState;
+      };
+    }
+  | {
+      type: "transportation/SET_SELECTED_REGIONS_TOTAL_EFFECTIVE_VEHICLES";
+      payload: {
+        selectedRegionsTotalEffectiveVehicles: SelectedRegionsTotalEffectiveVehicles;
       };
     }
   | {
@@ -420,12 +420,12 @@ type State = {
   vehicleFuelTypePercentagesOfVehicleType:
     | VehicleFuelTypePercentagesOfVehicleType
     | EmptyObject;
-  selectedRegionsTotalEffectiveVehicles:
-    | SelectedRegionsTotalEffectiveVehicles
-    | EmptyObject;
   vmtAndStockByState: VMTandStockByState | EmptyObject;
   ldvsFhwaMovesVMTRatioByState: LDVsFhwaMovesVMTRatioByState | EmptyObject;
   vmtPerVehicleTypeByState: VMTPerVehicleTypeByState | EmptyObject;
+  selectedRegionsTotalEffectiveVehicles:
+    | SelectedRegionsTotalEffectiveVehicles
+    | EmptyObject;
   selectedRegionsVMTPercentagesByState:
     | SelectedRegionsVMTPercentagesByState
     | EmptyObject;
@@ -503,10 +503,10 @@ const initialState: State = {
   vehicleCategoryTotals: {},
   vehicleTypePercentagesOfVehicleCategory: {},
   vehicleFuelTypePercentagesOfVehicleType: {},
-  selectedRegionsTotalEffectiveVehicles: {},
   vmtAndStockByState: {},
   ldvsFhwaMovesVMTRatioByState: {},
   vmtPerVehicleTypeByState: {},
+  selectedRegionsTotalEffectiveVehicles: {},
   selectedRegionsVMTPercentagesByState: {},
   selectedRegionsAverageVMTPerYear: {},
   selectedRegionsMonthlyVMT: {},
@@ -683,15 +683,6 @@ export default function reducer(
       };
     }
 
-    case "transportation/SET_SELECTED_REGIONS_TOTAL_EFFECTIVE_VEHICLES": {
-      const { selectedRegionsTotalEffectiveVehicles } = action.payload;
-
-      return {
-        ...state,
-        selectedRegionsTotalEffectiveVehicles,
-      };
-    }
-
     case "transportation/SET_VMT_AND_STOCK_BY_STATE": {
       const { vmtAndStockByState } = action.payload;
 
@@ -716,6 +707,15 @@ export default function reducer(
       return {
         ...state,
         vmtPerVehicleTypeByState,
+      };
+    }
+
+    case "transportation/SET_SELECTED_REGIONS_TOTAL_EFFECTIVE_VEHICLES": {
+      const { selectedRegionsTotalEffectiveVehicles } = action.payload;
+
+      return {
+        ...state,
+        selectedRegionsTotalEffectiveVehicles,
       };
     }
 

--- a/client/src/redux/reducers/transportation.ts
+++ b/client/src/redux/reducers/transportation.ts
@@ -10,6 +10,7 @@ import {
   type MonthlyVMTPercentages,
   type VMTTotalsByStateRegionCombo,
   type VMTTotalsByRegion,
+  type VMTTotalsByState,
   type VMTPercentagesByStateRegionCombo,
   type VehicleTypeTotals,
   type VehicleCategoryTotals,
@@ -51,6 +52,7 @@ import {
   calculateMonthlyVMTPercentages,
   calculateVMTTotalsByStateRegionCombo,
   calculateVMTTotalsByRegion,
+  calculateVMTTotalsByState,
   calculateVMTPercentagesByStateRegionCombo,
   calculateVehicleTypeTotals,
   calculateVehicleCategoryTotals,
@@ -193,6 +195,10 @@ type Action =
   | {
       type: "transportation/SET_VMT_TOTALS_BY_REGION";
       payload: { vmtTotalsByRegion: VMTTotalsByRegion };
+    }
+  | {
+      type: "transportation/SET_VMT_TOTALS_BY_STATE";
+      payload: { vmtTotalsByState: VMTTotalsByState };
     }
   | {
       type: "transportation/SET_VMT_PERCENTAGES_BY_STATE_REGION_COMBO";
@@ -391,6 +397,7 @@ type State = {
   monthlyVMTPercentages: MonthlyVMTPercentages | EmptyObject;
   vmtTotalsByStateRegionCombo: VMTTotalsByStateRegionCombo | EmptyObject;
   vmtTotalsByRegion: VMTTotalsByRegion | EmptyObject;
+  vmtTotalsByState: VMTTotalsByState | EmptyObject;
   vmtPercentagesByStateRegionCombo:
     | VMTPercentagesByStateRegionCombo
     | EmptyObject;
@@ -476,6 +483,7 @@ const initialState: State = {
   monthlyVMTPercentages: {},
   vmtTotalsByStateRegionCombo: {},
   vmtTotalsByRegion: {},
+  vmtTotalsByState: {},
   vmtPercentagesByStateRegionCombo: {},
   vehicleTypeTotals: {},
   vehicleCategoryTotals: {},
@@ -618,6 +626,15 @@ export default function reducer(
       return {
         ...state,
         vmtTotalsByRegion,
+      };
+    }
+
+    case "transportation/SET_VMT_TOTALS_BY_STATE": {
+      const { vmtTotalsByState } = action.payload;
+
+      return {
+        ...state,
+        vmtTotalsByState,
       };
     }
 
@@ -948,6 +965,10 @@ export function setVMTData(): AppThunk {
       vmtTotalsByStateRegionCombo,
     });
 
+    const vmtTotalsByState = calculateVMTTotalsByState({
+      vmtTotalsByStateRegionCombo,
+    });
+
     const vmtPercentagesByStateRegionCombo =
       calculateVMTPercentagesByStateRegionCombo({
         vmtTotalsByStateRegionCombo,
@@ -1018,6 +1039,11 @@ export function setVMTData(): AppThunk {
     dispatch({
       type: "transportation/SET_VMT_TOTALS_BY_REGION",
       payload: { vmtTotalsByRegion },
+    });
+
+    dispatch({
+      type: "transportation/SET_VMT_TOTALS_BY_STATE",
+      payload: { vmtTotalsByState },
     });
 
     dispatch({

--- a/client/src/redux/reducers/transportation.ts
+++ b/client/src/redux/reducers/transportation.ts
@@ -1254,8 +1254,9 @@ export function setDailyAndMonthlyStats(): AppThunk {
 export function setEffectiveVehicles(): AppThunk {
   return (dispatch, getState) => {
     const { geography, transportation, impacts } = getState();
-    const { regionalScalingFactors } = geography;
+    const { regions, regionalScalingFactors } = geography;
     const {
+      vmtStatePercentagesByStateRegionCombo,
       vehicleTypePercentagesOfVehicleCategory,
       vehicleFuelTypePercentagesOfVehicleType,
     } = transportation;
@@ -1269,13 +1270,26 @@ export function setEffectiveVehicles(): AppThunk {
       refuseTrucks,
     } = impacts.inputs;
 
+    const geographicFocus = geography.focus;
+
+    const selectedStateId =
+      Object.values(geography.states).find((s) => s.selected)?.id || "";
+
     const selectedGeographyRegionIds = Object.keys(
       regionalScalingFactors,
     ) as RegionId[];
 
+    const selectedGeographyRegions = getSelectedGeographyRegions({
+      regions,
+      selectedGeographyRegionIds,
+    });
+
     const selectedRegionsTotalEffectiveVehicles =
       calculateSelectedRegionsTotalEffectiveVehicles({
-        selectedGeographyRegionIds,
+        geographicFocus,
+        selectedStateId,
+        selectedGeographyRegions,
+        vmtStatePercentagesByStateRegionCombo,
         vehicleTypePercentagesOfVehicleCategory,
         vehicleFuelTypePercentagesOfVehicleType,
         batteryEVs: Number(batteryEVs),

--- a/client/src/redux/reducers/transportation.ts
+++ b/client/src/redux/reducers/transportation.ts
@@ -1239,14 +1239,17 @@ export function setDailyAndMonthlyStats(): AppThunk {
 }
 
 /**
- * Called every time the `impacts` reducer's `runEVBatteryEVsCalculations()`,
+ * Called every time the `geography` reducer's `selectGeography()`,
+ * `selectRegion()`, or `selectState()` functions are called and every time the
+ * `impacts` reducer's `runEVBatteryEVsCalculations()`,
  * `runEVHybridEVsCalculations()`, `runEVTransitBusesCalculations()`,
  * `runEVSchoolBusesCalculations()`, `runEVShortHaulTrucksCalculations()`,
  * `runEVComboLongHaulTrucksCalculations()`, or `runEVRefuseTrucksCalculations()`
  * functions are called.
  *
- * _(e.g. onBlur / whenever an EV input loses focus, but only if the input's
- * value has changed since the last time it was used in this calculation)_
+ * _(e.g. anytime the selected geography changes, and onBlur / whenever an EV
+ * input loses focus, but only if the input's value has changed since the last
+ * time it was used in this calculation)_
  */
 export function setEffectiveVehicles(): AppThunk {
   return (dispatch, getState) => {

--- a/client/src/redux/reducers/transportation.ts
+++ b/client/src/redux/reducers/transportation.ts
@@ -11,7 +11,8 @@ import {
   type VMTTotalsByStateRegionCombo,
   type VMTTotalsByRegion,
   type VMTTotalsByState,
-  type VMTPercentagesByStateRegionCombo,
+  type VMTRegionPercentagesByStateRegionCombo,
+  type VMTStatePercentagesByStateRegionCombo,
   type VehicleTypeTotals,
   type VehicleCategoryTotals,
   type VehicleTypePercentagesOfVehicleCategory,
@@ -53,7 +54,8 @@ import {
   calculateVMTTotalsByStateRegionCombo,
   calculateVMTTotalsByRegion,
   calculateVMTTotalsByState,
-  calculateVMTPercentagesByStateRegionCombo,
+  calculateVMTRegionPercentagesByStateRegionCombo,
+  calculateVMTStatePercentagesByStateRegionCombo,
   calculateVehicleTypeTotals,
   calculateVehicleCategoryTotals,
   calculateVehicleTypePercentagesOfVehicleCategory,
@@ -201,9 +203,15 @@ type Action =
       payload: { vmtTotalsByState: VMTTotalsByState };
     }
   | {
-      type: "transportation/SET_VMT_PERCENTAGES_BY_STATE_REGION_COMBO";
+      type: "transportation/SET_VMT_REGION_PERCENTAGES_BY_STATE_REGION_COMBO";
       payload: {
-        vmtPercentagesByStateRegionCombo: VMTTotalsByStateRegionCombo;
+        vmtRegionPercentagesByStateRegionCombo: VMTRegionPercentagesByStateRegionCombo;
+      };
+    }
+  | {
+      type: "transportation/SET_VMT_STATE_PERCENTAGES_BY_STATE_REGION_COMBO";
+      payload: {
+        vmtStatePercentagesByStateRegionCombo: VMTStatePercentagesByStateRegionCombo;
       };
     }
   | {
@@ -398,8 +406,11 @@ type State = {
   vmtTotalsByStateRegionCombo: VMTTotalsByStateRegionCombo | EmptyObject;
   vmtTotalsByRegion: VMTTotalsByRegion | EmptyObject;
   vmtTotalsByState: VMTTotalsByState | EmptyObject;
-  vmtPercentagesByStateRegionCombo:
-    | VMTPercentagesByStateRegionCombo
+  vmtRegionPercentagesByStateRegionCombo:
+    | VMTRegionPercentagesByStateRegionCombo
+    | EmptyObject;
+  vmtStatePercentagesByStateRegionCombo:
+    | VMTStatePercentagesByStateRegionCombo
     | EmptyObject;
   vehicleTypeTotals: VehicleTypeTotals | EmptyObject;
   vehicleCategoryTotals: VehicleCategoryTotals | EmptyObject;
@@ -484,7 +495,8 @@ const initialState: State = {
   vmtTotalsByStateRegionCombo: {},
   vmtTotalsByRegion: {},
   vmtTotalsByState: {},
-  vmtPercentagesByStateRegionCombo: {},
+  vmtRegionPercentagesByStateRegionCombo: {},
+  vmtStatePercentagesByStateRegionCombo: {},
   vehicleTypeTotals: {},
   vehicleCategoryTotals: {},
   vehicleTypePercentagesOfVehicleCategory: {},
@@ -638,12 +650,21 @@ export default function reducer(
       };
     }
 
-    case "transportation/SET_VMT_PERCENTAGES_BY_STATE_REGION_COMBO": {
-      const { vmtPercentagesByStateRegionCombo } = action.payload;
+    case "transportation/SET_VMT_REGION_PERCENTAGES_BY_STATE_REGION_COMBO": {
+      const { vmtRegionPercentagesByStateRegionCombo } = action.payload;
 
       return {
         ...state,
-        vmtPercentagesByStateRegionCombo,
+        vmtRegionPercentagesByStateRegionCombo,
+      };
+    }
+
+    case "transportation/SET_VMT_STATE_PERCENTAGES_BY_STATE_REGION_COMBO": {
+      const { vmtStatePercentagesByStateRegionCombo } = action.payload;
+
+      return {
+        ...state,
+        vmtStatePercentagesByStateRegionCombo,
       };
     }
 
@@ -969,10 +990,16 @@ export function setVMTData(): AppThunk {
       vmtTotalsByStateRegionCombo,
     });
 
-    const vmtPercentagesByStateRegionCombo =
-      calculateVMTPercentagesByStateRegionCombo({
+    const vmtRegionPercentagesByStateRegionCombo =
+      calculateVMTRegionPercentagesByStateRegionCombo({
         vmtTotalsByStateRegionCombo,
         vmtTotalsByRegion,
+      });
+
+    const vmtStatePercentagesByStateRegionCombo =
+      calculateVMTStatePercentagesByStateRegionCombo({
+        vmtTotalsByStateRegionCombo,
+        vmtTotalsByState,
       });
 
     const vehicleTypeTotals = calculateVehicleTypeTotals({
@@ -1047,8 +1074,13 @@ export function setVMTData(): AppThunk {
     });
 
     dispatch({
-      type: "transportation/SET_VMT_PERCENTAGES_BY_STATE_REGION_COMBO",
-      payload: { vmtPercentagesByStateRegionCombo },
+      type: "transportation/SET_VMT_REGION_PERCENTAGES_BY_STATE_REGION_COMBO",
+      payload: { vmtRegionPercentagesByStateRegionCombo },
+    });
+
+    dispatch({
+      type: "transportation/SET_VMT_STATE_PERCENTAGES_BY_STATE_REGION_COMBO",
+      payload: { vmtStatePercentagesByStateRegionCombo },
     });
 
     dispatch({
@@ -1114,7 +1146,7 @@ export function setSelectedGeographyVMTData(): AppThunk {
   return (dispatch, getState) => {
     const { geography, transportation } = getState();
     const { regions, regionalScalingFactors } = geography;
-    const { vmtPercentagesByStateRegionCombo } = transportation;
+    const { vmtRegionPercentagesByStateRegionCombo } = transportation;
 
     const selectedGeographyRegionIds = Object.keys(
       regionalScalingFactors,
@@ -1128,7 +1160,7 @@ export function setSelectedGeographyVMTData(): AppThunk {
     const selectedRegionsVMTPercentagesByState =
       calculateSelectedRegionsVMTPercentagesByState({
         selectedGeographyRegions,
-        vmtPercentagesByStateRegionCombo,
+        vmtRegionPercentagesByStateRegionCombo,
       });
 
     dispatch({

--- a/docs/excel.md
+++ b/docs/excel.md
@@ -7,7 +7,7 @@ JavaScript/JSON equivalents of Excel workbook tables
 Part III. Model Year and ICE Replacement  
 [evModelYearOptions](../client/src/config.ts#L1065)  
 [iceReplacementVehicleOptions](../client/src/config.ts#L1078)  
-[initialEVModelYear](../client/src/redux/reducers/impacts.ts#299)
+[initialEVModelYear](../client/src/redux/reducers/impacts.ts#L299)
 
 ## ES_Detail
 
@@ -17,8 +17,8 @@ Part II. Charging Characteristics
 ## 11_VehicleCty
 
 "From vehicles" column  
-[calculateVMTTotalsByGeography()](../client/src/calculations/transportation.ts#L471)  
-[calculateVehicleEmissionChangesByGeography()](../client/src/calculations/transportation.ts#L3386)
+[calculateVMTTotalsByGeography()](../client/src/calculations/transportation.ts#L475)  
+[calculateVehicleEmissionChangesByGeography()](../client/src/calculations/transportation.ts#L3587)
 
 ## CalculateEERE
 
@@ -44,14 +44,14 @@ Several columns of the left/first table
 [calculateHourlyEVLoad()](../client/src/calculations/impacts.ts#L458)
 
 Data from the top of the middle table  
-[storeHourlyEVLoadProfiles()](../client/src/calculations/transportation.ts#L321)
+[storeHourlyEVLoadProfiles()](../client/src/calculations/transportation.ts#L325)
 
 Data from the middle of the middle table  
-[calculateSelectedRegionsMonthlyDailyEnergyUsage](../client/src/calculations/transportation.ts#L2482)
+[calculateSelectedRegionsMonthlyDailyEnergyUsage()](../client/src/calculations/transportation.ts#L2673)
 
 Data from the bottom of the middle table  
-[calculateMonthlyStats()](../client/src/calculations/transportation.ts#L416)  
-[calculateSelectedRegionsMonthlyEnergyUsage()](../client/src/calculations/transportation.ts#L2405)
+[calculateMonthlyStats()](../client/src/calculations/transportation.ts#L420)  
+[calculateSelectedRegionsMonthlyEnergyUsage()](../client/src/calculations/transportation.ts#L2596)
 
 "Utility Scale" and "Distributed" columns of right/last table  
 [calculateHourlyEnergyStorageData()](../client/src/calculations/impacts.ts#L97)
@@ -67,7 +67,7 @@ Table 3: EGUs with infrequent SO2 emission events
 [regions[:regionId].actualEmissions](../client/src/config.ts#L393)
 
 Table 4: VMT per vehicle assumptions  
-[calculateSelectedRegionsAverageVMTPerYear()](../client/src/calculations/transportation.ts#L1598)
+[calculateSelectedRegionsAverageVMTPerYear()](../client/src/calculations/transportation.ts#L1779)
 
 Table 5: EV efficiency assumptions  
 [evEfficiencyAssumptions - ev-efficiency-assumptions.json](../client/src/data/ev-efficiency-assumptions.json)  
@@ -75,27 +75,27 @@ Table 5: EV efficiency assumptions
 
 Table 6: Monthly VMT and efficiency adjustments  
 [schoolBusMonthlyVMTPercentages](../client/src/config.ts#L189)  
-[calculateMonthlyVMTTotals()](../client/src/calculations/transportation.ts#L615)  
-[calculateYearlyVMTTotals()](../client/src/calculations/transportation.ts#L697)  
-[calculateMonthlyVMTPercentages()](../client/src/calculations/transportation.ts#L745)  
-[calculateSelectedRegionsMonthlyVMT()](../client/src/calculations/transportation.ts#L1702)  
-[calculateSelectedRegionsEVEfficiency()](../client/src/calculations/transportation.ts#L1791)
+[calculateMonthlyVMTTotals()](../client/src/calculations/transportation.ts#L619)  
+[calculateYearlyVMTTotals()](../client/src/calculations/transportation.ts#L701)  
+[calculateMonthlyVMTPercentages()](../client/src/calculations/transportation.ts#L749)  
+[calculateSelectedRegionsMonthlyVMT()](../client/src/calculations/transportation.ts#L1883)  
+[calculateSelectedRegionsEVEfficiency()](../client/src/calculations/transportation.ts#L1972)
 
 Table 7: Emission rates of vehicle types  
-[calculateSelectedRegionsMonthlyEmissionRates()](../client/src/calculations/transportation.ts#L1876)  
-[calculateSelectedRegionsMonthlyElectricityPM25EmissionRates](../client/src/calculations/transportation.ts#L2013)  
-[calculateSelectedRegionsMonthlyTotalNetPM25EmissionRates()](../client/src/calculations/transportation.ts#L2118)
+[calculateSelectedRegionsMonthlyEmissionRates()](../client/src/calculations/transportation.ts#L2057)  
+[calculateSelectedRegionsMonthlyElectricityPM25EmissionRates()](../client/src/calculations/transportation.ts#L2194)  
+[calculateSelectedRegionsMonthlyTotalNetPM25EmissionRates()](../client/src/calculations/transportation.ts#L2299)
 
 Table 8: Calculated changes for the transportation sector 
-[calculateTotalEffectiveVehicles()](../client/src/calculations/transportation.ts#L1258)  
-[calculateSelectedRegionsMonthlySalesChanges()](../client/src/calculations/transportation.ts#L2201)  
-[calculateSelectedRegionsYearlySalesChanges()](../client/src/calculations/transportation.ts#L2313)  
-[calculateSelectedRegionsTotalYearlySalesChanges()](../client/src/calculations/transportation.ts#L2367)  
-[calculateSelectedRegionsMonthlyEmissionChanges()](../client/src/calculations/transportation.ts#L2583)  
-[calculateSelectedRegionsMonthlyEmissionChangesPerVehicleCategory()](../client/src/calculations/transportation.ts#L2702)  
-[calculateSelectedRegionsYearlyEmissionChangesPerVehicleCategory()](../client/src/calculations/transportation.ts#L2798)  
-[calculateSelectedRegionsMonthlyEmissionChangesTotals()](../client/src/calculations/transportation.ts#L2875)  
-[calculateSelectedRegionsYearlyEmissionChangesTotals()](../client/src/calculations/transportation.ts#L2948)
+[calculateSelectedRegionsTotalEffectiveVehicles()](../client/src/calculations/transportation.ts#L1541)  
+[calculateSelectedRegionsMonthlySalesChanges()](../client/src/calculations/transportation.ts#L2382)  
+[calculateSelectedRegionsYearlySalesChanges()](../client/src/calculations/transportation.ts#L2504)  
+[calculateSelectedRegionsTotalYearlySalesChanges()](../client/src/calculations/transportation.ts#L2558)  
+[calculateSelectedRegionsMonthlyEmissionChanges()](../client/src/calculations/transportation.ts#L2774)  
+[calculateSelectedRegionsMonthlyEmissionChangesPerVehicleCategory()](../client/src/calculations/transportation.ts#L2903)  
+[calculateSelectedRegionsYearlyEmissionChangesPerVehicleCategory()](../client/src/calculations/transportation.ts#L2999)  
+[calculateSelectedRegionsMonthlyEmissionChangesTotals()](../client/src/calculations/transportation.ts#L3076)  
+[calculateSelectedRegionsYearlyEmissionChangesTotals()](../client/src/calculations/transportation.ts#L3149)
 
 Table 9: Default EV load profiles and related values from EVI-Pro Lite  
 [defaultEVLoadProfiles - default-ev-load-profiles.json](../client/src/data/default-ev-load-profiles.json)  
@@ -105,25 +105,25 @@ Table 9: Default EV load profiles and related values from EVI-Pro Lite
 [calculateClimateAdjustmentFactorByRegion()](../client/src/calculations/geography.ts#L135)
 
 Table 10: List of states in region for purposes of calculating vehicle sales and stock  
-[calculateSelectedGeographySalesAndStockByState()](../client/src/calculations/transportation.ts#L3007)  
-[calculateSelectedGeographySalesAndStockByRegion()](../client/src/calculations/transportation.ts#L3142)
+[calculateSelectedGeographySalesAndStockByState()](../client/src/calculations/transportation.ts#L3208)  
+[calculateSelectedGeographySalesAndStockByRegion()](../client/src/calculations/transportation.ts#L3343)
 
 Table 11: Historical renewable and energy efficiency addition data  
 [historicalRegionEEREData - historical-region-eere-data.json](../client/src/data/historical-region-eere-data.json)  
 [historicalStateEEREData - historical-state-eere-data.json](../client/src/data/historical-state-eere-data.json)  
-[calculateEVDeploymentLocationHistoricalEERE()](../client/src/calculations/transportation.ts#L3260)  
-[regionAnnualWholesaleImpacts](../client/src/calculations/transportation.ts#L3297)
+[calculateEVDeploymentLocationHistoricalEERE()](../client/src/calculations/transportation.ts#L3461)  
+[regionAnnualWholesaleImpacts](../client/src/calculations/transportation.ts#L3498)
 
 Table 12: Vehicle sales by type  
 [ldvsPercentagesByVehicleCategory](../client/src/config.ts#L262)  
-[calculateVehicleTypeTotals()](../client/src/calculations/transportation.ts#L1020)  
-[calculateVehicleCategoryTotals()](../client/src/calculations/transportation.ts#L1062)  
-[calculateVehicleTypePercentagesOfVehicleCategory()](../client/src/calculations/transportation.ts#L1111)  
-[calculateVehicleFuelTypePercentagesOfVehicleType()](../client/src/calculations/transportation.ts#L1198)
+[calculateVehicleTypeTotals()](../client/src/calculations/transportation.ts#L1153)  
+[calculateVehicleCategoryTotals()](../client/src/calculations/transportation.ts#L1195)  
+[calculateVehicleTypePercentagesOfVehicleCategory()](../client/src/calculations/transportation.ts#L1244)  
+[calculateVehicleFuelTypePercentagesOfVehicleType()](../client/src/calculations/transportation.ts#L1331)
 
 Table 13: First-Year ICE to EV PM2.5 brakewear and tirewear emissions rate conversion factors  
 [pm25BreakwearTirewearEVICERatios - pm25-breakwear-tirewear-ev-ice-ratios.json](../client/src/data/pm25-breakwear-tirewear-ev-ice-ratios.json)  
-[calculateSelectedRegionsEEREDefaultsAverages()](../client/src/calculations/transportation.ts#L3199)
+[calculateSelectedRegionsEEREDefaultsAverages()](../client/src/calculations/transportation.ts#L3400)
 
 Table 14: Lithium Ion Storage Defaults  
 [batteryRoundTripEfficiency](../client/src/config.ts#L300)
@@ -143,25 +143,27 @@ Table 14: Lithium Ion Storage Defaults
 ## RegionStateAllocate
 
 Top left table  
-[calculateVMTTotalsByStateRegionCombo()](../client/src/calculations/transportation.ts#L828)
+[calculateVMTTotalsByStateRegionCombo()](../client/src/calculations/transportation.ts#L832)
 
 Top right table  
-[calculateVMTPercentagesByStateRegionCombo()](../client/src/calculations/transportation.ts#L946)
+[calculateVMTRegionPercentagesByStateRegionCombo()](../client/src/calculations/transportation.ts#L1006)  
+[calculateVMTStatePercentagesByStateRegionCombo()](../client/src/calculations/transportation.ts#L1079)
 
 Bottom left table  
-[calculateVMTTotalsByRegion()](../client/src/calculations/transportation.ts#L892)
+[calculateVMTTotalsByRegion()](../client/src/calculations/transportation.ts#L896)  
+[calculateVMTTotalsByState()](../client/src/calculations/transportation.ts#L952)
 
 ## MOVESsupplement
 
 A. State-level VMT per vehicle  
 [stateLevelVMT - state-level-vmt.json](../client/src/data/state-level-vmt.json)  
-[storeVMTandStockByState()](../client/src/calculations/transportation.ts#L1365)  
-[calculateVMTPerVehicleTypeByState()](../client/src/calculations/transportation.ts#L1451)  
-[calculateSelectedRegionsVMTPercentagesByState()](../client/src/calculations/transportation.ts#L1515)
+[storeVMTandStockByState()](../client/src/calculations/transportation.ts#L1391)  
+[calculateVMTPerVehicleTypeByState()](../client/src/calculations/transportation.ts#L1477)  
+[calculateSelectedRegionsVMTPercentagesByState()](../client/src/calculations/transportation.ts#L1696)
 
 B. State-Level Sales  
 [stateLevelSales - state-level-sales.json](../client/src/data/state-level-sales.json)
 
 C. FHWA LDV State-Level VMT  
 [fhwaLDVStateLevelVMT - fhwa-ldv-state-level-vmt.json](../client/src/data/fhwa-ldv-state-level-vmt.json)  
-[calculateLDVsFhwaMovesVMTRatioByState()](../client/src/calculations/transportation.ts#L1411)
+[calculateLDVsFhwaMovesVMTRatioByState()](../client/src/calculations/transportation.ts#L1437)


### PR DESCRIPTION
Update app to store total effective vehicles for each selected region, and calculate the percentage/share of each state's total VMT for its AVERT region for each vehicle type. Now when a state is selected, we scale each total effective values for each vehicle type by the percentage/share of the state's total VMT for its AVERT region for that vehicle type.